### PR TITLE
Added sqlite backend + refactor "cli.py"

### DIFF
--- a/credentialdigger/__init__.py
+++ b/credentialdigger/__init__.py
@@ -1,2 +1,4 @@
-from .cli import Client
+from .client import Client
+from .client_postgres import PgClient
+from .client_sqlite import SqliteClient
 from .download import download

--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -17,6 +17,15 @@ Discovery = namedtuple('Discovery',
 
 
 class Interface(ABC):
+    """
+    Abstract class that simplifies queries for python database module
+    that implements Python Database API Specification v2.0 (PEP 249).
+
+    Parameters
+    ----------
+    db: database class (as defined in Python Database API Specification v2.0 (PEP 249))
+    Error: base exception class for the corresponding database type
+    """
     def __init__(self, db, error):
         self.db = db
         self.Error = error

--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -26,11 +26,12 @@ class Interface(ABC):
     db: database class (as defined in Python Database API Specification v2.0 (PEP 249))
     Error: base exception class for the corresponding database type
     """
+
     def __init__(self, db, error):
         self.db = db
         self.Error = error
 
-    def query(self, query, args = None):
+    def query(self, query, args=None):
         cursor = self.db.cursor()
         try:
             cursor.execute(query, [args])
@@ -45,14 +46,14 @@ class Interface(ABC):
             return False
 
     @abstractmethod
-    def query_check(self, query, args = None):
+    def query_check(self, query, args=None):
         return
 
     @abstractmethod
-    def query_id(self, query, args = None):
+    def query_id(self, query, args=None):
         return
 
-    def query_as(self, query, cast, args = None):
+    def query_as(self, query, cast, args=None):
         cursor = self.db.cursor()
         try:
             cursor.execute(query, args)
@@ -65,6 +66,7 @@ class Interface(ABC):
         except self.Error:
             self.db.rollback()
             return ()
+
 
 class Client(Interface):
     def __init__(self, db, error):
@@ -94,9 +96,9 @@ class Client(Interface):
             The id of the new discovery (-1 in case of error)
         """
         return self.query_id(
-            query = query,
-            args = (file_name, commit_id, snippet, repo_url,
-                                   rule_id, state)
+            query=query,
+            args=(file_name, commit_id, snippet, repo_url,
+                  rule_id, state)
         )
 
     def add_repo(self, query, repo_url):
@@ -115,7 +117,7 @@ class Client(Interface):
         bool
             `True` if the insert was successfull, `False` otherwise
         """
-        return self.query(query = query, args = (repo_url))
+        return self.query(query=query, args=(repo_url))
 
     def add_rule(self, query, regex, category, description=''):
         """ Add a new rule.
@@ -134,7 +136,7 @@ class Client(Interface):
         int
             The id of the new rule (-1 in case of errors)
         """
-        return self.query_id(query = query, args = (regex, category, description))
+        return self.query_id(query=query, args=(regex, category, description))
 
     def delete_rule(self, query, ruleid):
         """Delete a rule from database
@@ -180,8 +182,8 @@ class Client(Interface):
             `True` if the repo was successfully deleted, `False` otherwise
         """
         return self.query_check(
-            query = query,
-            args = (repo_url)
+            query=query,
+            args=(repo_url)
         )
 
     def add_rules_from_files(self, filename):
@@ -206,8 +208,8 @@ class Client(Interface):
             data = yaml.safe_load(f)
         for rule in data['rules']:
             self.add_rule(rule['regex'],
-                        rule['category'],
-                        rule.get('description', ''))
+                          rule['category'],
+                          rule.get('description', ''))
 
     def get_repos(self):
         """ Get all the repositories.
@@ -236,7 +238,7 @@ class Client(Interface):
         except self.Error:
             self.db.rollback()
             return []
-            
+
     def get_repo(self, query, repo_url):
         """ Get a repository.
 
@@ -292,7 +294,7 @@ class Client(Interface):
         cursor = self.db.cursor()
         try:
             all_rules = []
-            
+
             if category is not None:
                 cursor.execute(query, (category,))
             else:
@@ -326,9 +328,9 @@ class Client(Interface):
             A rule
         """
         return self.query_as(
-            query = query, 
-            cast = Rule,
-            args = (rule_id)
+            query=query,
+            cast=Rule,
+            args=(rule_id)
         )
 
     def get_discoveries(self, query, repo_url):
@@ -376,9 +378,9 @@ class Client(Interface):
             A discovery
         """
         return self.query_as(
-            query = query,
-            cast = Discovery,
-            args = (discovery_id)
+            query=query,
+            cast=Discovery,
+            args=(discovery_id)
         )
 
     def get_discovery_group(self, query, state_query, repo_url, state=None):
@@ -435,8 +437,8 @@ class Client(Interface):
             `True` if the update is successful, `False` otherwise
         """
         return self.query_check(
-            query = query,
-            args = (last_commit, url)
+            query=query,
+            args=(last_commit, url)
         )
 
     def update_discovery(self, query, discovery_id, new_state):
@@ -459,8 +461,8 @@ class Client(Interface):
             return False
 
         return self.query_check(
-            query = query,
-            args = (new_state, discovery_id)
+            query=query,
+            args=(new_state, discovery_id)
         )
 
     def update_discovery_group(self, query, repo_url, file_name, snippet, new_state):
@@ -489,8 +491,8 @@ class Client(Interface):
                              'not_relevant', 'fixed'):
             return False
         return self.query_check(
-            query = query,
-            args = (new_state, repo_url, file_name, snippet)
+            query=query,
+            args=(new_state, repo_url, file_name, snippet)
         )
 
     def scan(self, repo_url, category=None, scanner=GitScanner,
@@ -567,7 +569,7 @@ class Client(Interface):
             models = []
         if exclude is None:
             exclude = []
-            
+
         # Try to add the repository to the db
         if self.add_repo(repo_url):
             # The repository is new, scan from the first commit
@@ -806,5 +808,3 @@ class Client(Interface):
         """
         eg = ExtractorGenerator()
         return eg.generate_leak_snippets(repo_url)
-
-

--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -21,10 +21,10 @@ class Interface(ABC):
         self.db = db
         self.Error = error
 
-    def query(self, query, kwargs = None):
+    def query(self, query, args = None):
         cursor = self.db.cursor()
         try:
-            cursor.execute(query, [kwargs])
+            cursor.execute(query, [args])
             self.db.commit()
         except (TypeError, IndexError):
             """ A TypeError is raised if any of the required arguments is
@@ -36,17 +36,17 @@ class Interface(ABC):
             return False
 
     @abstractmethod
-    def query_check(self, query, kwargs = None):
+    def query_check(self, query, args = None):
         return
 
     @abstractmethod
-    def query_id(self, query, kwargs = None):
+    def query_id(self, query, args = None):
         return
 
-    def query_as(self, query, cast, kwargs = None):
+    def query_as(self, query, cast, args = None):
         cursor = self.db.cursor()
         try:
-            cursor.execute(query, kwargs)
+            cursor.execute(query, args)
             return dict(cast(*cursor.fetchone())._asdict())
         except (TypeError, IndexError):
             """ A TypeError is raised if any of the required arguments is
@@ -86,7 +86,7 @@ class Client(Interface):
         """
         return self.query_id(
             query = query,
-            kwargs = (file_name, commit_id, snippet, repo_url,
+            args = (file_name, commit_id, snippet, repo_url,
                                    rule_id, state)
         )
 
@@ -106,7 +106,7 @@ class Client(Interface):
         bool
             `True` if the insert was successfull, `False` otherwise
         """
-        return self.query(query = query, kwargs = (repo_url))
+        return self.query(query = query, args = (repo_url))
 
     def add_rule(self, query, regex, category, description=''):
         """ Add a new rule.
@@ -125,7 +125,7 @@ class Client(Interface):
         int
             The id of the new rule (-1 in case of errors)
         """
-        return self.query_id(query = query, kwargs = (regex, category, description))
+        return self.query_id(query = query, args = (regex, category, description))
 
     def delete_rule(self, query, ruleid):
         """Delete a rule from database
@@ -172,7 +172,7 @@ class Client(Interface):
         """
         return self.query_check(
             query = query,
-            kwargs = (repo_url)
+            args = (repo_url)
         )
 
     def add_rules_from_files(self, filename):
@@ -319,7 +319,7 @@ class Client(Interface):
         return self.query_as(
             query = query, 
             cast = Rule,
-            kwargs = (rule_id)
+            args = (rule_id)
         )
 
     def get_discoveries(self, query, repo_url):
@@ -369,7 +369,7 @@ class Client(Interface):
         return self.query_as(
             query = query,
             cast = Discovery,
-            kwargs = (discovery_id)
+            args = (discovery_id)
         )
 
     def get_discovery_group(self, query, state_query, repo_url, state=None):
@@ -427,7 +427,7 @@ class Client(Interface):
         """
         return self.query_check(
             query = query,
-            kwargs = (last_commit, url)
+            args = (last_commit, url)
         )
 
     def update_discovery(self, query, discovery_id, new_state):
@@ -451,7 +451,7 @@ class Client(Interface):
 
         return self.query_check(
             query = query,
-            kwargs = (new_state, discovery_id)
+            args = (new_state, discovery_id)
         )
 
     def update_discovery_group(self, query, repo_url, file_name, snippet, new_state):
@@ -481,7 +481,7 @@ class Client(Interface):
             return False
         return self.query_check(
             query = query,
-            kwargs = (new_state, repo_url, file_name, snippet)
+            args = (new_state, repo_url, file_name, snippet)
         )
 
     def scan(self, repo_url, category=None, scanner=GitScanner,

--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -16,7 +16,7 @@ Discovery = namedtuple('Discovery',
                        timestamp')
 
 
-class Interface():
+class Interface(ABC):
     def __init__(self, db, error):
         self.db = db
         self.Error = error
@@ -35,11 +35,13 @@ class Interface():
             self.db.rollback()
             return False
 
+    @abstractmethod
     def query_check(self, query, kwargs = None):
-        pass
+        return
 
+    @abstractmethod
     def query_id(self, query, kwargs = None):
-        pass
+        return
 
     def query_as(self, query, cast, kwargs = None):
         cursor = self.db.cursor()

--- a/credentialdigger/client_postgres.py
+++ b/credentialdigger/client_postgres.py
@@ -1,0 +1,375 @@
+from psycopg2 import connect, Error
+import yaml
+
+from collections import namedtuple
+from github import Github
+from tqdm import tqdm
+
+from .generator import ExtractorGenerator
+from .models.model_manager import ModelManager
+from .scanners.git_scanner import GitScanner
+
+from .client import Client, Rule, Repo, Discovery
+
+class PgClient(Client): 
+    def __init__(self, dbname, dbuser, dbpassword,
+                 dbhost = 'localhost', dbport = 5432):
+        """ Create a connection to the postgres database.
+
+        The PgClient is the interface object in charge of all the operations on the
+        database, and in charge of launching the scans.
+
+        Parameters
+        ----------
+        dbname: str
+            The name of the database
+        dbuser: str
+            The user of the database
+        dbpassword: str
+            The password for the user
+        dbhost: str, default `localhost`
+            The host of the database
+        dbport: int, default `5432`
+            The port for the database connection
+
+        Raises
+        ------
+        OperationalError
+            If the Client cannot connect to the database
+        """
+        super().__init__(connect(
+                            host=dbhost,
+                            dbname=dbname,
+                            user=dbuser,
+                            password=dbpassword,
+                            port=dbport), 
+                            Error)
+    
+    def query_check(self, query, kwargs = None):
+        cursor = self.db.cursor()
+        try:
+            cursor.execute(query, kwargs)
+            self.db.commit()
+            return bool(cursor.fetchone()[0])
+        except (TypeError, IndexError):
+            """ A TypeError is raised if any of the required arguments is
+            missing. """
+            self.db.rollback()
+            return False
+        except self.Error:
+            self.db.rollback()
+
+    def query_id(self, query, kwargs = None):
+        cursor = self.db.cursor()
+        try:
+            cursor.execute(query, kwargs)
+            self.db.commit()
+            return int(cursor.fetchone()[0])
+        except (TypeError, IndexError):
+            """ A TypeError is raised if any of the required arguments is
+            missing. """
+            self.db.rollback()
+            return -1
+        except Error:
+            self.db.rollback()
+            return -1
+
+    def add_discovery(self, file_name, commit_id, snippet, repo_url, rule_id,
+                      state='new'):
+        """ Add a new discovery.
+
+        Parameters
+        ----------
+        file_name: str
+            The name of the file that produced the discovery
+        commit_id: str
+            The id of the commit introducing the discovery
+        snippet: str
+            The line matched during the scan
+        repo_url: str
+            The url of the repository
+        rule_id: str
+            The id of the rule used during the scan
+        state: str, default `new`
+            The state of the discovery
+
+        Returns
+        -------
+        int
+            The id of the new discovery (-1 in case of error)
+        """
+        return super().add_discovery(
+            file_name = file_name,
+            commit_id = commit_id,
+            snippet = snippet,
+            repo_url = repo_url,
+            rule_id = rule_id,
+            state = state,
+            query = 'INSERT INTO discoveries (file_name, commit_id, snippet, \
+            repo_url, rule_id, state) VALUES (%s, %s, %s, %s, %s, %s) \
+            RETURNING id'
+        )
+
+    def add_repo(self, repo_url):
+        """ Add a new repository.
+
+        Do not set the latest commit (it will be set when the repository is
+        scanned).
+
+        Parameters
+        ----------
+        repo_url: str
+            The url of the repository
+
+        Returns
+        -------
+        bool
+            `True` if the insert was successfull, `False` otherwise
+        """
+        return super().add_repo(repo_url= repo_url, 
+            query='INSERT INTO repos (url) VALUES (%s) RETURNING true')
+        
+    def add_rule(self, regex, category, description=''):
+        """ Add a new rule.
+
+        Parameters
+        ----------
+        regex: str
+            The regex to be matched
+        category: str
+            The category of the rule
+        description: str, optional
+            The description of the rule
+
+        Returns
+        -------
+        int
+            The id of the new rule (-1 in case of errors)
+        """
+        return super().add_rule(
+            regex = regex,
+            category = category,
+            description = description,
+            query = 'INSERT INTO rules (regex, category, description) \
+                    VALUES (%s, %s, %s) RETURNING id'
+        )
+
+    def delete_rule(self, ruleid):
+        """Delete a rule from database
+
+        Parameters
+        ----------
+        ruleid: int
+            The id of the rule that will be deleted.
+
+        Returns
+        ------
+        False
+            If the removal operation fails
+        True
+            Otherwise
+        """
+        return super().delete_rule(ruleid = ruleid,
+               query = 'DELETE FROM rules WHERE id=%s')
+
+    def delete_repo(self, repo_url):
+        """ Delete a repository.
+
+        Parameters
+        ----------
+        repo_id: int
+            The id of the repo to delete
+
+        Returns
+        -------
+        bool
+            `True` if the repo was successfully deleted, `False` otherwise
+        """
+        return super().delete_repo(
+            repo_url = repo_url,
+            query = 'DELETE FROM repos WHERE url=%s RETURNING true'
+        )
+
+    def get_repo(self, repo_url):
+        """ Get a repository.
+
+        Parameters
+        ----------
+        repo_url: str
+            The url of the repo
+
+        Returns
+        -------
+        dict
+            A repository (an empty dictionary if the url does not exist)
+        """
+        return super().get_repo(repo_url=repo_url, query='SELECT * FROM repos WHERE url=%s')
+
+    def get_rules(self, category=None):
+        """ Get the rules.
+
+        Differently from other get methods, here we pass the category as
+        argument. This is due to the fact that categories may have a slash
+        (e.g., `auth/password`). Encoding such categories in the url would
+        cause an error on the server side.
+
+        Parameters
+        ----------
+        category: str, optional
+            If specified get all the rules, otherwise get all the rules of this
+            category
+
+        Returns
+        -------
+        list
+            A list of rules (dictionaries)
+        """
+        return super().get_rules(category=category,
+            category_query='SELECT * FROM rules WHERE category=%s')
+
+    def get_rule(self, rule_id):
+        """ Get a rule.
+
+        Parameters
+        ----------
+        rule_id: int
+            The id of the rule
+
+        Returns
+        -------
+        dict
+            A rule
+        """
+        return super().get_rule(rule_id = rule_id,
+            query='SELECT * FROM rules WHERE id=%s')
+
+    def get_discoveries(self, repo_url):
+        """ Get all the discoveries of a repository.
+
+        Parameters
+        ----------
+        repo_url: str
+            The url of the repository
+
+        Returns
+        -------
+        list
+            A list of discoveries (dictionaries)
+        """
+        return super().get_discoveries(repo_url = repo_url,
+            query = 'SELECT * FROM discoveries WHERE repo_url=%s')
+
+    def get_discovery(self, discovery_id):
+        """ Get a discovery.
+
+        Parameters
+        ----------
+        discovery_id: int
+            The id of the discovery
+
+        Returns
+        -------
+        dict
+            A discovery
+        """
+        super().get_discovery(discovery_id = discovery_id,
+            query = 'SELECT * FROM discoveries WHERE id=%s')
+
+    def get_discovery_group(self, repo_url, state=None):
+        """ Get all the discoveries of a repository, grouped by file_name,
+        snippet, and state.
+
+        Parameters
+        ----------
+        repo_url: str
+            The url of the repository
+        state: str, optional
+            The state of the discoveries. If not set, get all the discoveries
+            independently from their state
+
+        Returns
+        -------
+        list
+            A list of tuples. Each tuple is composed by file_name, snippet,
+            number of times that this couple occurs, and the state of the
+            couple.
+        """
+        return super().get_discovery_group(repo_url = repo_url,
+                state_query = 'SELECT file_name, snippet, count(id), state FROM \
+                discoveries WHERE repo_url=%s AND state=%s GROUP BY file_name,\
+                snippet, state',
+                query = 'SELECT file_name, snippet, count(id), state FROM discoveries \
+                WHERE repo_url=%s GROUP BY file_name, snippet, state'
+        )
+
+    def update_repo(self, url, last_commit):
+        """ Update the last commit of a repo.
+
+        After a scan, record what is the most recent commit scanned, such that
+        another (future) scan will not process the same commits twice.
+
+        Parameters
+        ----------
+        url: str
+            The url of the repository scanned
+        last_commit: str
+            The most recent commit scanned
+
+        Returns
+        -------
+        bool
+            `True` if the update is successful, `False` otherwise
+        """
+        super().update_repo(
+            url = url, last_commit = last_commit,
+            query = 'UPDATE repos SET last_commit=%s WHERE url=%s RETURNING true'
+        )
+
+    def update_discovery(self, discovery_id, new_state):
+        """ Change the state of a discovery.
+
+        Parameters
+        ----------
+        discovery_id: int
+            The id of the discovery to be updated
+        new_state: str
+            The new state of this discovery
+
+        Returns
+        -------
+        bool
+            `True` if the update is successful, `False` otherwise
+        """
+        super().update_discovery(
+            discovery_id = discovery_id, new_state = new_state,
+            query = 'UPDATE discoveries SET state=%s WHERE id=%s RETURNING true'
+        ) 
+        
+    def update_discovery_group(self, repo_url, file_name, snippet, new_state):
+        """ Change the state of a group of discoveries.
+
+        A group of discoveries is identified by the url of their repository,
+        their filename,and their snippet.
+
+        Parameters
+        ----------
+        repo_url: str
+            The url of the repository
+        file_name: str
+            The name of the file
+        snippet: str
+            The snippet
+        new_state: str
+            The new state of this discovery
+
+        Returns
+        -------
+        bool
+            `True` if the update is successful, `False` otherwise
+        """
+        super().update_discovery_group(
+            repo_url = repo_url, file_name = file_name,
+            snippet = snippet, new_state = new_state,
+            query = 'UPDATE discoveries SET state=%s WHERE repo_url=%s \
+                    and file_name=%s and snippet=%s RETURNING true'
+        )

--- a/credentialdigger/client_postgres.py
+++ b/credentialdigger/client_postgres.py
@@ -11,9 +11,10 @@ from .scanners.git_scanner import GitScanner
 
 from .client import Client, Rule, Repo, Discovery
 
-class PgClient(Client): 
+
+class PgClient(Client):
     def __init__(self, dbname, dbuser, dbpassword,
-                 dbhost = 'localhost', dbport = 5432):
+                 dbhost='localhost', dbport=5432):
         """ Create a connection to the postgres database.
 
         The PgClient is the interface object in charge of all the operations on the
@@ -38,14 +39,14 @@ class PgClient(Client):
             If the Client cannot connect to the database
         """
         super().__init__(connect(
-                            host=dbhost,
-                            dbname=dbname,
-                            user=dbuser,
-                            password=dbpassword,
-                            port=dbport), 
-                            Error)
-    
-    def query_check(self, query, args = None):
+            host=dbhost,
+            dbname=dbname,
+            user=dbuser,
+            password=dbpassword,
+            port=dbport),
+            Error)
+
+    def query_check(self, query, args=None):
         cursor = self.db.cursor()
         try:
             cursor.execute(query, args)
@@ -59,7 +60,7 @@ class PgClient(Client):
         except self.Error:
             self.db.rollback()
 
-    def query_id(self, query, args = None):
+    def query_id(self, query, args=None):
         cursor = self.db.cursor()
         try:
             cursor.execute(query, args)
@@ -99,13 +100,13 @@ class PgClient(Client):
             The id of the new discovery (-1 in case of error)
         """
         return super().add_discovery(
-            file_name = file_name,
-            commit_id = commit_id,
-            snippet = snippet,
-            repo_url = repo_url,
-            rule_id = rule_id,
-            state = state,
-            query = 'INSERT INTO discoveries (file_name, commit_id, snippet, \
+            file_name=file_name,
+            commit_id=commit_id,
+            snippet=snippet,
+            repo_url=repo_url,
+            rule_id=rule_id,
+            state=state,
+            query='INSERT INTO discoveries (file_name, commit_id, snippet, \
             repo_url, rule_id, state) VALUES (%s, %s, %s, %s, %s, %s) \
             RETURNING id'
         )
@@ -126,9 +127,9 @@ class PgClient(Client):
         bool
             `True` if the insert was successfull, `False` otherwise
         """
-        return super().add_repo(repo_url= repo_url, 
-            query='INSERT INTO repos (url) VALUES (%s) RETURNING true')
-        
+        return super().add_repo(repo_url=repo_url,
+                                query='INSERT INTO repos (url) VALUES (%s) RETURNING true')
+
     def add_rule(self, regex, category, description=''):
         """ Add a new rule.
 
@@ -147,10 +148,10 @@ class PgClient(Client):
             The id of the new rule (-1 in case of errors)
         """
         return super().add_rule(
-            regex = regex,
-            category = category,
-            description = description,
-            query = 'INSERT INTO rules (regex, category, description) \
+            regex=regex,
+            category=category,
+            description=description,
+            query='INSERT INTO rules (regex, category, description) \
                     VALUES (%s, %s, %s) RETURNING id'
         )
 
@@ -169,8 +170,8 @@ class PgClient(Client):
         True
             Otherwise
         """
-        return super().delete_rule(ruleid = ruleid,
-               query = 'DELETE FROM rules WHERE id=%s')
+        return super().delete_rule(ruleid=ruleid,
+                                   query='DELETE FROM rules WHERE id=%s')
 
     def delete_repo(self, repo_url):
         """ Delete a repository.
@@ -186,8 +187,8 @@ class PgClient(Client):
             `True` if the repo was successfully deleted, `False` otherwise
         """
         return super().delete_repo(
-            repo_url = repo_url,
-            query = 'DELETE FROM repos WHERE url=%s RETURNING true'
+            repo_url=repo_url,
+            query='DELETE FROM repos WHERE url=%s RETURNING true'
         )
 
     def get_repo(self, repo_url):
@@ -225,7 +226,7 @@ class PgClient(Client):
             A list of rules (dictionaries)
         """
         return super().get_rules(category=category,
-            category_query='SELECT * FROM rules WHERE category=%s')
+                                 category_query='SELECT * FROM rules WHERE category=%s')
 
     def get_rule(self, rule_id):
         """ Get a rule.
@@ -240,8 +241,8 @@ class PgClient(Client):
         dict
             A rule
         """
-        return super().get_rule(rule_id = rule_id,
-            query='SELECT * FROM rules WHERE id=%s')
+        return super().get_rule(rule_id=rule_id,
+                                query='SELECT * FROM rules WHERE id=%s')
 
     def get_discoveries(self, repo_url):
         """ Get all the discoveries of a repository.
@@ -256,8 +257,8 @@ class PgClient(Client):
         list
             A list of discoveries (dictionaries)
         """
-        return super().get_discoveries(repo_url = repo_url,
-            query = 'SELECT * FROM discoveries WHERE repo_url=%s')
+        return super().get_discoveries(repo_url=repo_url,
+                                       query='SELECT * FROM discoveries WHERE repo_url=%s')
 
     def get_discovery(self, discovery_id):
         """ Get a discovery.
@@ -272,8 +273,8 @@ class PgClient(Client):
         dict
             A discovery
         """
-        super().get_discovery(discovery_id = discovery_id,
-            query = 'SELECT * FROM discoveries WHERE id=%s')
+        super().get_discovery(discovery_id=discovery_id,
+                              query='SELECT * FROM discoveries WHERE id=%s')
 
     def get_discovery_group(self, repo_url, state=None):
         """ Get all the discoveries of a repository, grouped by file_name,
@@ -294,13 +295,13 @@ class PgClient(Client):
             number of times that this couple occurs, and the state of the
             couple.
         """
-        return super().get_discovery_group(repo_url = repo_url,
-                state_query = 'SELECT file_name, snippet, count(id), state FROM \
+        return super().get_discovery_group(repo_url=repo_url,
+                                           state_query='SELECT file_name, snippet, count(id), state FROM \
                 discoveries WHERE repo_url=%s AND state=%s GROUP BY file_name,\
                 snippet, state',
-                query = 'SELECT file_name, snippet, count(id), state FROM discoveries \
+                                           query='SELECT file_name, snippet, count(id), state FROM discoveries \
                 WHERE repo_url=%s GROUP BY file_name, snippet, state'
-        )
+                                           )
 
     def update_repo(self, url, last_commit):
         """ Update the last commit of a repo.
@@ -321,8 +322,8 @@ class PgClient(Client):
             `True` if the update is successful, `False` otherwise
         """
         super().update_repo(
-            url = url, last_commit = last_commit,
-            query = 'UPDATE repos SET last_commit=%s WHERE url=%s RETURNING true'
+            url=url, last_commit=last_commit,
+            query='UPDATE repos SET last_commit=%s WHERE url=%s RETURNING true'
         )
 
     def update_discovery(self, discovery_id, new_state):
@@ -341,10 +342,10 @@ class PgClient(Client):
             `True` if the update is successful, `False` otherwise
         """
         super().update_discovery(
-            discovery_id = discovery_id, new_state = new_state,
-            query = 'UPDATE discoveries SET state=%s WHERE id=%s RETURNING true'
-        ) 
-        
+            discovery_id=discovery_id, new_state=new_state,
+            query='UPDATE discoveries SET state=%s WHERE id=%s RETURNING true'
+        )
+
     def update_discovery_group(self, repo_url, file_name, snippet, new_state):
         """ Change the state of a group of discoveries.
 
@@ -368,8 +369,8 @@ class PgClient(Client):
             `True` if the update is successful, `False` otherwise
         """
         super().update_discovery_group(
-            repo_url = repo_url, file_name = file_name,
-            snippet = snippet, new_state = new_state,
-            query = 'UPDATE discoveries SET state=%s WHERE repo_url=%s \
+            repo_url=repo_url, file_name=file_name,
+            snippet=snippet, new_state=new_state,
+            query='UPDATE discoveries SET state=%s WHERE repo_url=%s \
                     and file_name=%s and snippet=%s RETURNING true'
         )

--- a/credentialdigger/client_postgres.py
+++ b/credentialdigger/client_postgres.py
@@ -45,10 +45,10 @@ class PgClient(Client):
                             port=dbport), 
                             Error)
     
-    def query_check(self, query, kwargs = None):
+    def query_check(self, query, args = None):
         cursor = self.db.cursor()
         try:
-            cursor.execute(query, kwargs)
+            cursor.execute(query, args)
             self.db.commit()
             return bool(cursor.fetchone()[0])
         except (TypeError, IndexError):
@@ -59,10 +59,10 @@ class PgClient(Client):
         except self.Error:
             self.db.rollback()
 
-    def query_id(self, query, kwargs = None):
+    def query_id(self, query, args = None):
         cursor = self.db.cursor()
         try:
-            cursor.execute(query, kwargs)
+            cursor.execute(query, args)
             self.db.commit()
             return int(cursor.fetchone()[0])
         except (TypeError, IndexError):

--- a/credentialdigger/client_sqlite.py
+++ b/credentialdigger/client_sqlite.py
@@ -11,6 +11,7 @@ from .scanners.git_scanner import GitScanner
 
 from .client import Client, Rule, Repo, Discovery
 
+
 class SqliteClient(Client):
     def __init__(self, path):
         """ Create/connects to a sqlite database.
@@ -23,7 +24,7 @@ class SqliteClient(Client):
         path: str
             Database file (':memory:' is in RAM memory)
         """
-        super().__init__(connect(database = path), Error)
+        super().__init__(connect(database=path), Error)
         # Create database if not exist
         cursor = self.db.cursor()
         cursor.executescript("""
@@ -56,8 +57,8 @@ class SqliteClient(Client):
             );
         """)
         cursor.close()
-    
-    def query_check(self, query, args = None):
+
+    def query_check(self, query, args=None):
         cursor = self.db.cursor()
         try:
             cursor.execute(query, args)
@@ -72,7 +73,7 @@ class SqliteClient(Client):
             self.db.rollback()
         cursor.close()
 
-    def query_id(self, query, args = None):
+    def query_id(self, query, args=None):
         cursor = self.db.cursor()
         try:
             cursor.execute(query, args)
@@ -113,13 +114,13 @@ class SqliteClient(Client):
             The id of the new discovery (-1 in case of error)
         """
         return super().add_discovery(
-            file_name = file_name,
-            commit_id = commit_id,
-            snippet = snippet,
-            repo_url = repo_url,
-            rule_id = rule_id,
-            state = state,
-            query = 'INSERT INTO discoveries (file_name, commit_id, snippet, \
+            file_name=file_name,
+            commit_id=commit_id,
+            snippet=snippet,
+            repo_url=repo_url,
+            rule_id=rule_id,
+            state=state,
+            query='INSERT INTO discoveries (file_name, commit_id, snippet, \
             repo_url, rule_id, state) VALUES (?, ?, ?, ?, ?, ?)'
         )
 
@@ -139,8 +140,8 @@ class SqliteClient(Client):
         bool
             `True` if the insert was successfull, `False` otherwise
         """
-        return super().add_repo(repo_url=repo_url, 
-            query='INSERT INTO repos (url) VALUES (?);')
+        return super().add_repo(repo_url=repo_url,
+                                query='INSERT INTO repos (url) VALUES (?);')
 
     def add_rule(self, regex, category, description=''):
         """ Add a new rule.
@@ -160,10 +161,10 @@ class SqliteClient(Client):
             The id of the new rule (-1 in case of errors)
         """
         return super().add_rule(
-            regex = regex,
-            category = category,
-            description = description,
-            query = 'INSERT INTO rules (regex, category, description) VALUES (?, ?, ?)'
+            regex=regex,
+            category=category,
+            description=description,
+            query='INSERT INTO rules (regex, category, description) VALUES (?, ?, ?)'
         )
 
     def delete_rule(self, ruleid):
@@ -181,9 +182,9 @@ class SqliteClient(Client):
         True
             Otherwise
         """
-        return super().delete_rule(ruleid = ruleid,
-               query = 'DELETE FROM rules WHERE id=?')
-    
+        return super().delete_rule(ruleid=ruleid,
+                                   query='DELETE FROM rules WHERE id=?')
+
     def delete_repo(self, repo_url):
         """ Delete a repository.
 
@@ -198,8 +199,8 @@ class SqliteClient(Client):
             `True` if the repo was successfully deleted, `False` otherwise
         """
         return super().delete_repo(
-            repo_url = repo_url,
-            query = 'DELETE FROM repos WHERE url=?'
+            repo_url=repo_url,
+            query='DELETE FROM repos WHERE url=?'
         )
 
     def get_repo(self, repo_url):
@@ -237,7 +238,7 @@ class SqliteClient(Client):
             A list of rules (dictionaries)
         """
         return super().get_rules(category=category,
-            category_query='SELECT * FROM rules WHERE category=?')
+                                 category_query='SELECT * FROM rules WHERE category=?')
 
     def get_rule(self, rule_id):
         """ Get a rule.
@@ -252,8 +253,8 @@ class SqliteClient(Client):
         dict
             A rule
         """
-        return super().get_rule(rule_id = rule_id,
-            query='SELECT * FROM rules WHERE id=?')
+        return super().get_rule(rule_id=rule_id,
+                                query='SELECT * FROM rules WHERE id=?')
 
     def get_discoveries(self, repo_url):
         """ Get all the discoveries of a repository.
@@ -268,8 +269,8 @@ class SqliteClient(Client):
         list
             A list of discoveries (dictionaries)
         """
-        return super().get_discoveries(repo_url = repo_url,
-            query = 'SELECT * FROM discoveries WHERE repo_url=?')
+        return super().get_discoveries(repo_url=repo_url,
+                                       query='SELECT * FROM discoveries WHERE repo_url=?')
 
     def get_discovery(self, discovery_id):
         """ Get a discovery.
@@ -284,8 +285,8 @@ class SqliteClient(Client):
         dict
             A discovery
         """
-        super().get_discovery(discovery_id = discovery_id,
-            query = 'SELECT * FROM discoveries WHERE id=?')
+        super().get_discovery(discovery_id=discovery_id,
+                              query='SELECT * FROM discoveries WHERE id=?')
 
     def get_discovery_group(self, repo_url, state=None):
         """ Get all the discoveries of a repository, grouped by file_name,
@@ -306,13 +307,13 @@ class SqliteClient(Client):
             number of times that this couple occurs, and the state of the
             couple.
         """
-        return super().get_discovery_group(repo_url = repo_url,
-                state_query = 'SELECT file_name, snippet, count(id), state FROM \
+        return super().get_discovery_group(repo_url=repo_url,
+                                           state_query='SELECT file_name, snippet, count(id), state FROM \
                 discoveries WHERE repo_url=? AND state=? GROUP BY file_name,\
                 snippet, state',
-                query = 'SELECT file_name, snippet, count(id), state FROM discoveries \
+                                           query='SELECT file_name, snippet, count(id), state FROM discoveries \
                 WHERE repo_url=? GROUP BY file_name, snippet, state'
-        )
+                                           )
 
     def update_repo(self, url, last_commit):
         """ Update the last commit of a repo.
@@ -333,10 +334,10 @@ class SqliteClient(Client):
             `True` if the update is successful, `False` otherwise
         """
         super().update_repo(
-            url = url, last_commit = last_commit,
-            query = 'UPDATE repos SET last_commit=? WHERE url=?'
+            url=url, last_commit=last_commit,
+            query='UPDATE repos SET last_commit=? WHERE url=?'
         )
-    
+
     def update_discovery_group(self, repo_url, file_name, snippet, new_state):
         """ Change the state of a group of discoveries.
 
@@ -360,8 +361,8 @@ class SqliteClient(Client):
             `True` if the update is successful, `False` otherwise
         """
         super().update_discovery_group(
-            repo_url = repo_url, file_name = file_name,
-            snippet = snippet, new_state = new_state,
-            query = 'UPDATE discoveries SET state=? WHERE repo_url=? \
+            repo_url=repo_url, file_name=file_name,
+            snippet=snippet, new_state=new_state,
+            query='UPDATE discoveries SET state=? WHERE repo_url=? \
                     and file_name=? and snippet=?'
         )

--- a/credentialdigger/client_sqlite.py
+++ b/credentialdigger/client_sqlite.py
@@ -57,10 +57,10 @@ class SqliteClient(Client):
         """)
         cursor.close()
     
-    def query_check(self, query, kwargs = None):
+    def query_check(self, query, args = None):
         cursor = self.db.cursor()
         try:
-            cursor.execute(query, kwargs)
+            cursor.execute(query, args)
             self.db.commit()
             return cursor.rowcount < 1
         except (TypeError, IndexError):
@@ -72,10 +72,10 @@ class SqliteClient(Client):
             self.db.rollback()
         cursor.close()
 
-    def query_id(self, query, kwargs = None):
+    def query_id(self, query, args = None):
         cursor = self.db.cursor()
         try:
-            cursor.execute(query, kwargs)
+            cursor.execute(query, args)
             self.db.commit()
             return cursor.lastrowid
         except (TypeError, IndexError):

--- a/credentialdigger/client_sqlite.py
+++ b/credentialdigger/client_sqlite.py
@@ -1,0 +1,367 @@
+from sqlite3 import connect, Error
+import yaml
+
+from collections import namedtuple
+from github import Github
+from tqdm import tqdm
+
+from .generator import ExtractorGenerator
+from .models.model_manager import ModelManager
+from .scanners.git_scanner import GitScanner
+
+from .client import Client, Rule, Repo, Discovery
+
+class SqliteClient(Client):
+    def __init__(self, path):
+        """ Create/connects to a sqlite database.
+
+        The SqliteClient is the interface object in charge of all the operations on the
+        database, and in charge of launching the scans.
+
+        Parameters
+        ----------
+        path: str
+            Database file (':memory:' is in RAM memory)
+        """
+        super().__init__(connect(database = path), Error)
+        # Create database if not exist
+        cursor = self.db.cursor()
+        cursor.executescript("""
+            CREATE TABLE IF NOT EXISTS repos(
+                url TEXT NOT NULL UNIQUE,
+                last_commit TEXT,
+                PRIMARY KEY (url)
+            );
+
+            CREATE TABLE IF NOT EXISTS rules(
+                id INTEGER,
+                regex TEXT NOT NULL UNIQUE,
+                category TEXT,
+                description TEXT,
+                PRIMARY KEY (id)
+            );
+
+            CREATE TABLE IF NOT EXISTS discoveries(
+                id INTEGER,
+                file_name TEXT NOT NULL,
+                commit_id TEXT NOT NULL,
+                snippet TEXT DEFAULT '',
+                repo_url TEXT,
+                rule_id INTEGER,
+                state TEXT NOT NULL DEFAULT 'new',
+                timestamp TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M','now', 'localtime')),
+                PRIMARY KEY (id),
+                FOREIGN KEY (repo_url) REFERENCES repos ON DELETE CASCADE ON UPDATE CASCADE,
+                FOREIGN KEY (rule_id) REFERENCES rules ON DELETE NO ACTION ON UPDATE CASCADE
+            );
+        """)
+        cursor.close()
+    
+    def query_check(self, query, kwargs = None):
+        cursor = self.db.cursor()
+        try:
+            cursor.execute(query, kwargs)
+            self.db.commit()
+            return cursor.rowcount < 1
+        except (TypeError, IndexError):
+            """ A TypeError is raised if any of the required arguments is
+            missing. """
+            self.db.rollback()
+            return False
+        except self.Error:
+            self.db.rollback()
+        cursor.close()
+
+    def query_id(self, query, kwargs = None):
+        cursor = self.db.cursor()
+        try:
+            cursor.execute(query, kwargs)
+            self.db.commit()
+            return cursor.lastrowid
+        except (TypeError, IndexError):
+            """ A TypeError is raised if any of the required arguments is
+            missing. """
+            self.db.rollback()
+            return -1
+        except Error:
+            self.db.rollback()
+            return -1
+        cursor.close()
+
+    def add_discovery(self, file_name, commit_id, snippet, repo_url, rule_id,
+                      state='new'):
+        """ Add a new discovery.
+
+        Parameters
+        ----------
+        file_name: str
+            The name of the file that produced the discovery
+        commit_id: str
+            The id of the commit introducing the discovery
+        snippet: str
+            The line matched during the scan
+        repo_url: str
+            The url of the repository
+        rule_id: str
+            The id of the rule used during the scan
+        state: str, default `new`
+            The state of the discovery
+
+        Returns
+        -------
+        int
+            The id of the new discovery (-1 in case of error)
+        """
+        return super().add_discovery(
+            file_name = file_name,
+            commit_id = commit_id,
+            snippet = snippet,
+            repo_url = repo_url,
+            rule_id = rule_id,
+            state = state,
+            query = 'INSERT INTO discoveries (file_name, commit_id, snippet, \
+            repo_url, rule_id, state) VALUES (?, ?, ?, ?, ?, ?)'
+        )
+
+    def add_repo(self, repo_url):
+        """ Add a new repository.
+
+        Do not set the latest commit (it will be set when the repository is
+        scanned).
+
+        Parameters
+        ----------
+        repo_url: str
+            The url of the repository
+
+        Returns
+        -------
+        bool
+            `True` if the insert was successfull, `False` otherwise
+        """
+        return super().add_repo(repo_url=repo_url, 
+            query='INSERT INTO repos (url) VALUES (?);')
+
+    def add_rule(self, regex, category, description=''):
+        """ Add a new rule.
+
+        Parameters
+        ----------
+        regex: str
+            The regex to be matched
+        category: str
+            The category of the rule
+        description: str, optional
+            The description of the rule
+
+        Returns
+        -------
+        int
+            The id of the new rule (-1 in case of errors)
+        """
+        return super().add_rule(
+            regex = regex,
+            category = category,
+            description = description,
+            query = 'INSERT INTO rules (regex, category, description) VALUES (?, ?, ?)'
+        )
+
+    def delete_rule(self, ruleid):
+        """Delete a rule from database
+
+        Parameters
+        ----------
+        ruleid: int
+            The id of the rule that will be deleted.
+
+        Returns
+        ------
+        False
+            If the removal operation fails
+        True
+            Otherwise
+        """
+        return super().delete_rule(ruleid = ruleid,
+               query = 'DELETE FROM rules WHERE id=?')
+    
+    def delete_repo(self, repo_url):
+        """ Delete a repository.
+
+        Parameters
+        ----------
+        repo_id: int
+            The id of the repo to delete
+
+        Returns
+        -------
+        bool
+            `True` if the repo was successfully deleted, `False` otherwise
+        """
+        return super().delete_repo(
+            repo_url = repo_url,
+            query = 'DELETE FROM repos WHERE url=?'
+        )
+
+    def get_repo(self, repo_url):
+        """ Get a repository.
+
+        Parameters
+        ----------
+        repo_url: str
+            The url of the repo
+
+        Returns
+        -------
+        dict
+            A repository (an empty dictionary if the url does not exist)
+        """
+        return super().get_repo(repo_url=repo_url, query='SELECT * FROM repos WHERE url=?')
+
+    def get_rules(self, category=None):
+        """ Get the rules.
+
+        Differently from other get methods, here we pass the category as
+        argument. This is due to the fact that categories may have a slash
+        (e.g., `auth/password`). Encoding such categories in the url would
+        cause an error on the server side.
+
+        Parameters
+        ----------
+        category: str, optional
+            If specified get all the rules, otherwise get all the rules of this
+            category
+
+        Returns
+        -------
+        list
+            A list of rules (dictionaries)
+        """
+        return super().get_rules(category=category,
+            category_query='SELECT * FROM rules WHERE category=?')
+
+    def get_rule(self, rule_id):
+        """ Get a rule.
+
+        Parameters
+        ----------
+        rule_id: int
+            The id of the rule
+
+        Returns
+        -------
+        dict
+            A rule
+        """
+        return super().get_rule(rule_id = rule_id,
+            query='SELECT * FROM rules WHERE id=?')
+
+    def get_discoveries(self, repo_url):
+        """ Get all the discoveries of a repository.
+
+        Parameters
+        ----------
+        repo_url: str
+            The url of the repository
+
+        Returns
+        -------
+        list
+            A list of discoveries (dictionaries)
+        """
+        return super().get_discoveries(repo_url = repo_url,
+            query = 'SELECT * FROM discoveries WHERE repo_url=?')
+
+    def get_discovery(self, discovery_id):
+        """ Get a discovery.
+
+        Parameters
+        ----------
+        discovery_id: int
+            The id of the discovery
+
+        Returns
+        -------
+        dict
+            A discovery
+        """
+        super().get_discovery(discovery_id = discovery_id,
+            query = 'SELECT * FROM discoveries WHERE id=?')
+
+    def get_discovery_group(self, repo_url, state=None):
+        """ Get all the discoveries of a repository, grouped by file_name,
+        snippet, and state.
+
+        Parameters
+        ----------
+        repo_url: str
+            The url of the repository
+        state: str, optional
+            The state of the discoveries. If not set, get all the discoveries
+            independently from their state
+
+        Returns
+        -------
+        list
+            A list of tuples. Each tuple is composed by file_name, snippet,
+            number of times that this couple occurs, and the state of the
+            couple.
+        """
+        return super().get_discovery_group(repo_url = repo_url,
+                state_query = 'SELECT file_name, snippet, count(id), state FROM \
+                discoveries WHERE repo_url=? AND state=? GROUP BY file_name,\
+                snippet, state',
+                query = 'SELECT file_name, snippet, count(id), state FROM discoveries \
+                WHERE repo_url=? GROUP BY file_name, snippet, state'
+        )
+
+    def update_repo(self, url, last_commit):
+        """ Update the last commit of a repo.
+
+        After a scan, record what is the most recent commit scanned, such that
+        another (future) scan will not process the same commits twice.
+
+        Parameters
+        ----------
+        url: str
+            The url of the repository scanned
+        last_commit: str
+            The most recent commit scanned
+
+        Returns
+        -------
+        bool
+            `True` if the update is successful, `False` otherwise
+        """
+        super().update_repo(
+            url = url, last_commit = last_commit,
+            query = 'UPDATE repos SET last_commit=? WHERE url=?'
+        )
+    
+    def update_discovery_group(self, repo_url, file_name, snippet, new_state):
+        """ Change the state of a group of discoveries.
+
+        A group of discoveries is identified by the url of their repository,
+        their filename,and their snippet.
+
+        Parameters
+        ----------
+        repo_url: str
+            The url of the repository
+        file_name: str
+            The name of the file
+        snippet: str
+            The snippet
+        new_state: str
+            The new state of this discovery
+
+        Returns
+        -------
+        bool
+            `True` if the update is successful, `False` otherwise
+        """
+        super().update_discovery_group(
+            repo_url = repo_url, file_name = file_name,
+            snippet = snippet, new_state = new_state,
+            query = 'UPDATE discoveries SET state=? WHERE repo_url=? \
+                    and file_name=? and snippet=?'
+        )

--- a/ui/server.py
+++ b/ui/server.py
@@ -3,7 +3,7 @@ from dotenv import load_dotenv
 from flask import Flask, request, render_template, redirect, send_file
 from werkzeug.utils import secure_filename
 
-from credentialdigger.cli import Client
+from credentialdigger.client_postgres import PgClient
 
 import yaml
 import os
@@ -14,11 +14,13 @@ load_dotenv()
 app = Flask('__name__', static_folder='res')
 app.config['UPLOAD_FOLDER'] = './backend'
 app.config['DEBUG'] = True  # Remove this line in production
-c = Client(dbname=os.getenv('POSTGRES_DB'),
-           dbuser=os.getenv('POSTGRES_USER'),
-           dbpassword=os.getenv('POSTGRES_PASSWORD'),
-           dbhost=os.getenv('DBHOST'),
-           dbport=int(os.getenv('DBPORT')))
+c = PgClient(
+    dbname=os.getenv('POSTGRES_DB'),
+    dbuser=os.getenv('POSTGRES_USER'),
+    dbpassword=os.getenv('POSTGRES_PASSWORD'),
+    dbhost=os.getenv('DBHOST'),
+    dbport=int(os.getenv('DBPORT'))
+)
 
 
 # ################### UI ####################


### PR DESCRIPTION
Features:
- Added sqlite as possible backend
- Refactored cli.py to three files:
   - `client.py` : "abstract" database interface
   - `client_postgres.py` : postgres interface (`PgClient()` using the same parameters as old `Client()`)
   - `client_sqlite.py` : sqlite interface (`SqliteClient(path = )`, path being the path to store the sqlite file. if `:memory:` is set as path, uses RAM for storage)

Benchmark: (includes clone time, data cleared after each run, run on `credential-digger` (~ 67 commits) repository and `eclipse/steady` (~1,317 commits) repository)
- postgres : (local database, running on docker)
    - credential-digger : 8.783954858779907s
    - eclipse/steady: 144.41976594924927s
- sqlite : (stored in fs, UNIX with very deep filesystem)
    - credential-digger : 46.96376991271973s
    - eclipse/steady : 652.9483344554901s
- sqlite RAM :
    - credential-digger : 5.340729475021362s
    - eclipse/steady : 50.553064584732056s

To-do:
- [ ] Test some database interface calls that aren't called in `scan()`
- [ ] Figure out if cursors should be closed or not (could cause memory leaks but could also improve performance thanks to caching done in cursor      ¯\\_(ツ)_/¯   )

Signed-off-by: Quoc Trung Hoang <quoc-trung.hoang@etu.utc.fr>