### PR TITLE
Added on-the-fly 'scan' command

### DIFF
--- a/credentialdigger/__init__.py
+++ b/credentialdigger/__init__.py
@@ -1,2 +1,3 @@
 from .cli import Client
 from .download import download
+from .scan import scan

--- a/credentialdigger/__main__.py
+++ b/credentialdigger/__main__.py
@@ -3,19 +3,19 @@ import logging
 if __name__ == "__main__":
     import plac
     import sys
-    from credentialdigger import download
+    from credentialdigger import download, scan
 
-    commands = {
-        'download': download
-    }
+    commands = {'download': download, 'scan': scan}
     available_comamnds = f'{", ".join(commands)}'
     if len(sys.argv) == 1:
-        logging.info(f'Available commands: {available_comamnds}')
+        logging.error(
+            f'You have not called any command.\nAvailable commands: {available_comamnds}'
+        )
+        exit()
     command = sys.argv.pop(1)
     sys.argv[0] = f'credentialdigger {command}'
     if command in commands:
         plac.call(commands[command], sys.argv[1:])
     else:
-        logging.error(
-            f'Unknown command: {command}\n'
-            f'Available commands: {available_comamnds}')
+        logging.error(f'Unknown command: {command}\n'
+                      f'Available commands: {available_comamnds}')

--- a/credentialdigger/__main__.py
+++ b/credentialdigger/__main__.py
@@ -9,7 +9,8 @@ if __name__ == "__main__":
     available_comamnds = f'{", ".join(commands)}'
     if len(sys.argv) == 1:
         logging.error(
-            f'You have not called any command.\nAvailable commands: {available_comamnds}'
+            f'You have not called any command.\n\
+            Available commands: {available_comamnds}'
         )
         exit()
     command = sys.argv.pop(1)

--- a/credentialdigger/__main__.py
+++ b/credentialdigger/__main__.py
@@ -9,7 +9,7 @@ if __name__ == "__main__":
     available_comamnds = f'{", ".join(commands)}'
     if len(sys.argv) == 1:
         logging.error(
-            f'You have not called any command.\n\
+            f'You did not call any command.\n\
             Available commands: {available_comamnds}'
         )
         exit()

--- a/credentialdigger/scan.py
+++ b/credentialdigger/scan.py
@@ -60,7 +60,6 @@ parser.add_argument(
     help='<Optional> If specified, scan the repo using all the \
                     rules of this category, otherwise use all the \
                     rules in the db')
-                    
 """
 This argument is deactivated since the scanner is 
 expecting a class, not a string.

--- a/credentialdigger/scan.py
+++ b/credentialdigger/scan.py
@@ -1,0 +1,144 @@
+"""
+The 'scan' module enables us to scan a git repository on the fly from the terminal.
+NOTE: Please make sure that the environmental variables have been exported.
+
+This command takes multiple arguments :
+  repo_url              <Required> The URL of the git repository to be
+                        scanned.
+  -h, --help            show this help message and exit
+  --category CATEGORY   <Optional> If specified, scan the repo using all the
+                        rules of this category, otherwise use all the rules in
+                        the db
+  --models MODELS [MODELS ...]
+                        <Optional> A list of models for the ML false positives
+                        detection. Cannot accept empty lists.
+  --exclude EXCLUDE [EXCLUDE ...]
+                        <Optional> A list of rules to exclude
+  --force               <Optional> Force a complete re-scan of the repository,
+                        in case it has already been scanned previously
+  --debug               <Optional> Flag used to decide whether to visualize
+                        the progressbars during the scan (e.g., during the
+                        insertion of the detections in the db)
+  --generate_snippet_extractor
+                        <Optional> Generate the extractor model to be used in
+                        the SnippetModel. The extractor is generated using the
+                        ExtractorGenerator. If `False`, use the pre-trained
+                        extractor model
+
+Usage:
+python -m credentialdigger scan REPO_URL --force --debug
+
+"""
+import argparse
+import logging
+import os
+import sys
+
+from credentialdigger.cli import Client
+
+logger = logging.getLogger(__name__)
+
+
+class customParser(argparse.ArgumentParser):
+    def error(self, message):
+        logger.error(f'{message}')
+        self.print_help()
+        exit()
+
+
+parser = customParser()
+
+parser.add_argument(
+    'repo_url',
+    type=str,
+    help='<Required> The URL of the git repository to be scanned.')
+
+parser.add_argument(
+    '--category',
+    default=None,
+    type=str,
+    help='<Optional> If specified, scan the repo using all the \
+                    rules of this category, otherwise use all the \
+                    rules in the db')
+                    
+"""
+This argument is deactivated since the scanner is 
+expecting a class, not a string.
+
+parser.add_argument('--scanner',
+                    default='GitScanner',
+                    type=str,
+                    help='<Optional> class, default: `GitScanner` \
+                        The class of the scanner, a subclass of \
+                        `scanners.BaseScanner`'
+                    )
+"""
+
+parser.add_argument('--models',
+                    default=None,
+                    nargs='+',
+                    help='<Optional> A list of models for the ML \
+                                    false positives detection.\n \
+                                    Cannot accept empty lists.')
+
+parser.add_argument('--exclude',
+                    default=None,
+                    nargs='+',
+                    help='<Optional> A list of rules to exclude')
+
+parser.add_argument(
+    '--force',
+    action='store_true',
+    help='<Optional> Force a complete re-scan of the repository, \
+                    in case it has already been scanned previously')
+
+parser.add_argument(
+    '--debug',
+    action='store_true',
+    help='<Optional> Flag used to decide whether to visualize the \
+                    progressbars during the scan (e.g., during the \
+                    insertion of the detections in the db)')
+
+parser.add_argument(
+    '--generate_snippet_extractor',
+    action='store_true',
+    help=
+    '<Optional> Generate the extractor model to be used in the SnippetModel.\
+                The extractor is generated using the ExtractorGenerator. If \
+                `False`, use the pre-trained extractor model')
+
+
+def scan(*pip_args):
+    """
+    Scan a git repository.
+    
+    Parameters
+    ----------
+    *pip_args
+        Keyword arguments for pip.
+    
+    Returns
+    -------
+        While this function returns nothing of use to the scanner itself, it gives an
+        exit status (integer) that is equal to the number of discoveries.
+        If it exits with a value that is equal to 0, then it means that the repo 
+        contains no leaks.
+    """
+    args = parser.parse_args(pip_args)
+
+    c = Client(dbname=os.getenv('POSTGRES_DB'),
+               dbuser=os.getenv('POSTGRES_USER'),
+               dbpassword=os.getenv('POSTGRES_PASSWORD'),
+               dbhost=os.getenv('DBHOST'),
+               dbport=int(os.getenv('DBPORT')))
+
+    discoveries = c.scan(
+        repo_url=args.repo_url,
+        category=args.category,
+        models=args.models,
+        exclude=args.exclude,
+        force=args.force,
+        debug=args.debug,
+        generate_snippet_extractor=args.generate_snippet_extractor)
+
+    sys.exit(len(discoveries))

--- a/credentialdigger/scan.py
+++ b/credentialdigger/scan.py
@@ -1,6 +1,6 @@
 """
 The 'scan' module enables us to scan a git repository on the fly from the terminal.
-NOTE: Please make sure that the environmental variables have been exported.
+NOTE: Please make sure that the environment variables are exported.
 
 This command takes multiple arguments :
   repo_url              <Required> The URL of the git repository to be


### PR DESCRIPTION
# Scan a git repo via the command line
## Overview
It is now possible to run a scan via the command line using the __scan__ command
#### Example
```bash
credentialdigger scan https://github.com/user/repo/ --debug
```
or

```bash
python -m credentialdigger scan https://github.com/user/repo/ --debug
```
### Requirements

- The package has to be already installed
- The environment variables have to be exported (Reference : [.env.sample](https://github.com/SAP/credential-digger/blob/master/.env.sample))

You can export the variables, if not done already, this way : 
```bash
set -a
. ./.env
set +a
```
## Usage
### Arguments
The __scan__ command enables us to scan a git repo directly via the command line. It also is customizable, and takes multiple arguments : 
```
  repo_url              <Required> The URL of the git repository to be
                        scanned.
  -h, --help            show this help message and exit
  --category CATEGORY   <Optional> If specified, scan the repo using all the
                        rules of this category, otherwise use all the rules in
                        the db
  --models MODELS [MODELS ...]
                        <Optional> A list of models for the ML false positives
                        detection. Cannot accept empty lists.
  --exclude EXCLUDE [EXCLUDE ...]
                        <Optional> A list of rules to exclude
  --force               <Optional> Force a complete re-scan of the repository,
                        in case it has already been scanned previously
  --debug               <Optional> Flag used to decide whether to visualize
                        the progressbars during the scan (e.g., during the
                        insertion of the detections in the db)
  --generate_snippet_extractor
                        <Optional> Generate the extractor model to be used in
                        the SnippetModel. The extractor is generated using the
                        ExtractorGenerator. If `False`, use the pre-trained
                        extractor model
``` 

### Examples
#### debug mode
```bash
python -m credentialdigger scan https://github.com/user/repo/ --debug
or
credentialdigger scan https://github.com/user/repo/ --debug
```
#### Specifying models
```bash
python -m credentialdigger scan https://github.com/user/repo/ --models SnippetModel PathModel --debug
or
credentialdigger scan https://github.com/user/repo/ --models SnippetModel PathModel --debug
```

# Extras
The __scan__ command also returns an exit status that is equal to the number of discoveries it has made during the scan.
Here are two samples on how we can make use of the exit status.
### Bash script
```bash
python -m credentialdigger scan https://github.com/user/repo
# $? = exit status
if [ $? -gt 0 ]; then
    echo "This repo contains leaks"
else
    echo "This repo contains no leaks"
fi
```
### Java program
```java
public class credentialdigger{
    public static void main(String[] args) {
        String command = "python -m credentialdigger scan https://github.com/user/repo";
        try {
            Process p = Runtime.getRuntime().exec(command);
            p.waitFor();
            int numberOfDiscoveries = p.exitValue();
            if(numberOfDiscoveries>0){
                System.out.println("This repo contains leaks.");
            }
            else{
                System.out.println("This repo contains no leaks.");
            }
        } catch (Exception e) {
            //IGNORE
        }
    }
}
```