### PR TITLE
Fixed show/hide FPs button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Logo](github_assets/Logo-CD-Mint_48.png)
+![Logo](https://raw.githubusercontent.com/SAP/credential-digger/master/github_assets/Logo-CD-Mint_48.png)
 
 # Credential Digger
 

--- a/ui/res/js/discoveries.js
+++ b/ui/res/js/discoveries.js
@@ -7,7 +7,7 @@ var filterFPs = false;
 var tableRows = document.getElementsByClassName('tableRowContent');
 // add action listeners to table rows
 for (var i = 0; i < tableRows.length; i++) {
-  tableRows[i].addEventListener('mouseover', function(event) {
+  tableRows[i].addEventListener('mouseover', function (event) {
     // open expand table row
     openExpandTableRow(event.currentTarget);
   });
@@ -41,18 +41,18 @@ function openExpandTableRow(tr) {
 
 // delete repo popup
 // add action listener to delete repo button
-document.getElementById('deleteRepo').addEventListener('click', function(event) {
+document.getElementById('deleteRepo').addEventListener('click', function (event) {
   // show popup
   document.getElementById('deleteRepoModal').style.display = 'block';
 });
 // add action listener for window (clicking anywhere)
-window.addEventListener('click', function(event) {
+window.addEventListener('click', function (event) {
   // if user clicks in the modal area (area around the popup) hide popup
   if (event.target == document.getElementById('deleteRepoModal')) {
     document.getElementById('deleteRepoModal').style.display = 'none';
   }
 });
-document.getElementById('cancelDeleteRepo').addEventListener('click', function(event) {
+document.getElementById('cancelDeleteRepo').addEventListener('click', function (event) {
   // hide popup
   document.getElementById('deleteRepoModal').style.display = 'none';
 });
@@ -60,30 +60,30 @@ document.getElementById('cancelDeleteRepo').addEventListener('click', function(e
 
 // New scan
 // add action listener to scan repo button
-document.getElementById('newScan').addEventListener('click', function(event) {
+document.getElementById('newScan').addEventListener('click', function (event) {
   // Show popup
   document.getElementById('addRepoModal').style.display = 'block';
 });
 // Add action listener for window (clicking anywhere)
-window.addEventListener('click', function(event) {
+window.addEventListener('click', function (event) {
   // if user clicks in the modal area (area around the popup) hide popup
   if (event.target == document.getElementById('addRepoModal')) {
     closeAddRepo();
   }
 });
 // add action listener to close scan repo popup
-document.getElementById('cancelAddRepo').addEventListener('click', function(event) {
+document.getElementById('cancelAddRepo').addEventListener('click', function (event) {
   // close popup
   closeAddRepo();
 });
 // add action listener to start repo scan
-document.getElementById('startRepoScan').addEventListener('click', function(event) {
+document.getElementById('startRepoScan').addEventListener('click', function (event) {
   // close popup
   document.getElementById('addRepoModal').style.display = 'none';
   // show loading popup
 });
 // add action listener to repo scan config selector
-document.getElementById('configSelector').addEventListener('change', function(event) {
+document.getElementById('configSelector').addEventListener('change', function (event) {
   // check if form is correctly filled
   var config = document.getElementById('configSelector').value;
   var postAddRepoButton = document.getElementById('startRepoScan');
@@ -103,7 +103,7 @@ function closeAddRepo() {
   // reset input
 }
 
-
+var allDiscoveries = document.getElementsByClassName('discoveryEntry');
 // Show/hide fp flag
 function switchFilter() {
   filterFPs = filterFPs ^ 1;
@@ -114,15 +114,16 @@ function switchFilter() {
 }
 
 function toggleFPs() {
-  if (filterFPs == false) {
-    location.reload();
-  }
-  var allDiscoveries = document.getElementsByClassName('discoveryEntry');
-  for (var i = 0; i < allDiscoveries.length; i += 2) {
+  let countDiscoveries = 0;
+  for (let i = 0; i < allDiscoveries.length; i++) {
     // If the discovery is not new, hide its row and the expandable one
-    if (allDiscoveries[i].children[2].valueOf().innerText != 'new') {
-      allDiscoveries[i].state.display = 'none';
-      allDiscoveries[i+1].state.display = 'none';
+    if (allDiscoveries[i].children[2].valueOf().innerText == 'false_positive') {
+      allDiscoveries[i].style.display = filterFPs ? 'none' : '';
+      countDiscoveries++;
     }
   }
+  document.getElementById('showFPs').innerHTML = filterFPs ? 'Show FPs' : 'Hide FPs';
+  document.getElementById('discoveriesCounter').innerHTML = filterFPs ?
+    `${allDiscoveries.length} discoveries found (${countDiscoveries} false positives are hidden)` :
+    `${allDiscoveries.length} discoveries found`;
 }

--- a/ui/templates/discoveries.html
+++ b/ui/templates/discoveries.html
@@ -12,7 +12,7 @@
 </div>
 
 <div class="topicHeaderWrapper underTopicHeaderWrapper">
-  <h3 class="scanDescription">{{lendiscoveries}} Discoveries found</h3>
+  <h3 id="discoveriesCounter" class="scanDescription">{{lendiscoveries}} Discoveries found</h3>
 </div>
 <div class="filtersWrapper">
   {% for cat in all_categories %}


### PR DESCRIPTION
# Overview
The toggle button that displays/hides the false positive has been fixed. (Targetted issue: https://github.com/SAP/credential-digger/issues/3)

### Notes
- This solution performs better than the one that has been proposed earlier since we are not retrieving the list of discoveries every time we filter out the FPs.
- This solution is not the fastest. It can be easily optimised in order to achieve further speed gains by introducing an array that contains the false positives the moment the window loads. We currently are traversing the array of discoveries every time we want to filter the FPs, which is not optimal. I will optimize it later. 
- This approach does not refresh the page, all the changes happen in-place.

