### PR TITLE
Fixed some SqliteClient issues

### DIFF
--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -185,7 +185,7 @@ class Client(Interface):
         bool
             `True` if the repo was successfully deleted, `False` otherwise
         """
-        return self.query_check(
+        return self.query(
             query=query,
             args=(repo_url)
         )

--- a/credentialdigger/client_sqlite.py
+++ b/credentialdigger/client_sqlite.py
@@ -56,6 +56,8 @@ class SqliteClient(Client):
                 FOREIGN KEY (repo_url) REFERENCES repos ON DELETE CASCADE ON UPDATE CASCADE,
                 FOREIGN KEY (rule_id) REFERENCES rules ON DELETE NO ACTION ON UPDATE CASCADE
             );
+
+            PRAGMA foreign_keys=ON
         """)
         cursor.close()
         self.db.commit()

--- a/credentialdigger/client_sqlite.py
+++ b/credentialdigger/client_sqlite.py
@@ -340,6 +340,26 @@ class SqliteClient(Client):
             query='UPDATE repos SET last_commit=? WHERE url=?'
         )
 
+    def update_discovery(self, discovery_id, new_state):
+        """ Change the state of a discovery.
+
+        Parameters
+        ----------
+        discovery_id: int
+            The id of the discovery to be updated
+        new_state: str
+            The new state of this discovery
+
+        Returns
+        -------
+        bool
+            `True` if the update is successful, `False` otherwise
+        """
+        super().update_discovery(
+            new_state=new_state, discovery_id=discovery_id,
+            query='UPDATE discoveries SET state=? WHERE id=?'
+        )
+
     def update_discovery_group(self, repo_url, file_name, snippet, new_state):
         """ Change the state of a group of discoveries.
 


### PR DESCRIPTION
### Added update_discovery() to the SqliteClient ✅
It is worth mentioning that ```RETURNING true;``` 
Reference: https://github.com/SAP/credential-digger/blob/91ecf9382f8ec5ef456f1ca9207c31907a8d0376/credentialdigger/client_postgres.py#L346
is not supported in SQLite, hence the slight difference between the two queries that are used.

### Updated delete_repo() ✅
The `delete_repo()` does not affect the database when it calls __query_check()__ instead of __query__.

### Activate Foreign Key Support ✅
Removing a repo that contains leaks will not remove the discoveries that are attached to it.
It seems that the support for foreign keys is `OFF` by default. Running `sqlite> PRAGMA foreign_keys;` returns __0__.

