### PR TITLE
Ignore the user's forks (or not)

### DIFF
--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -744,8 +744,7 @@ class Client(Interface):
         g = Github()
         missing_ids = {}
         for repo in g.get_user(username).get_repos():
-            if forks is False:
-                if repo.fork is True:
+            if forks is False and repo.fork is True:
                     # Ignore this repo since it is a fork
                     continue
             # Get repo clone url without .git at the end

--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -704,7 +704,7 @@ class Client(Interface):
         return list(discoveries_ids)
 
     def scan_user(self, username, category=None, models=None, exclude=None,
-                  debug=False, generate_snippet_extractor=False):
+                  debug=False, generate_snippet_extractor=False, forks=False):
         """ Scan all the repositories of a user on github.com.
 
         Find all the repositories of a user, and scan
@@ -744,6 +744,10 @@ class Client(Interface):
         g = Github()
         missing_ids = {}
         for repo in g.get_user(username).get_repos():
+            if forks is False:
+                if repo.fork is True:
+                    # Ignore this repo since it is a fork
+                    continue
             # Get repo clone url without .git at the end
             repo_url = repo.clone_url[:-4]
             logger.debug(f'Scanning {repo.url}')

--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -750,7 +750,7 @@ class Client(Interface):
                     continue
             # Get repo clone url without .git at the end
             repo_url = repo.clone_url[:-4]
-            logger.debug(f'Scanning {repo.url}')
+            logger.info(f'Scanning {repo.url}')
             missing_ids[repo_url] = self.scan(repo_url, category=category,
                                               models=models, exclude=exclude,
                                               scanner=GitScanner,


### PR DESCRIPTION
## Targetted issue
https://github.com/SAP/credential-digger/issues/31
### Overview
It is now possible to ignore (or not) the forks when scanning a user's list of repos.

### Usage
```python
from credentialdigger import PgClient
c = PgClient(dbname='', dbuser='',
                          dbpassword='',
                          dbhost='localhost', dbport=5432)
s = c.scan_user('username',forks=True)
```