### PR TITLE
ML models support + UI/UX enhancements + JS refactoring

### DIFF
--- a/ui/res/js/discoveries.js
+++ b/ui/res/js/discoveries.js
@@ -83,9 +83,9 @@ document.getElementById('startRepoScan').addEventListener('click', function (eve
   // show loading popup
 });
 // add action listener to repo scan config selector
-document.getElementById('configSelector').addEventListener('change', function (event) {
+document.getElementById('cbAllRules').addEventListener('change', function (event) {
   // check if form is correctly filled
-  var config = document.getElementById('configSelector').value;
+  var config = document.getElementById('cbAllRules').value;
   var postAddRepoButton = document.getElementById('startRepoScan');
   if (config != '') {
     postAddRepoButton.disabled = false;

--- a/ui/res/js/repos.js
+++ b/ui/res/js/repos.js
@@ -48,14 +48,14 @@ document.getElementById('cbAllRules').addEventListener('change', checkFormFilled
  */
 
 function checkFormFilled() {
-  // get post repo scan button and form values
+  // get HTML elements
   let cBox = document.getElementById('cbAllRules');
   let rulesList = document.getElementById('ruleSelector');
   let repoLinkContainer = document.getElementById('repoLinkInput');
   let repoLink = repoLinkContainer.value;
   // check if repo link is a valid url
   let urlValid = repoLink.match(/(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g);
-  // enable submit button if url is valid
+  // check whether the form is correctly filled or not.
   if (urlValid || cBox.checked || rulesList.selectedIndex != -1) {
     editForm(true);
   }

--- a/ui/res/js/repos.js
+++ b/ui/res/js/repos.js
@@ -62,7 +62,7 @@ function checkFormFilled() {
   if (urlValid == null) {
     editForm(false, Errors.URL, 'The URL you have provided is invalid.');
   }
-  if (cBox.checked == true || rulesList.selectedIndex == -1) {
+  if (cBox.checked == false && rulesList.selectedIndex == -1) {
     editForm(false, Errors.CATEGORY, 'Please select a category first.');
   }
 

--- a/ui/res/js/repos.js
+++ b/ui/res/js/repos.js
@@ -1,63 +1,107 @@
-// add search action listener
-document.getElementById('search').addEventListener('input', function() {
-  search(this.value);
-});
+/**
+ * URL: The URL is invalid.
+ * CATEGORY: The user must select one category.
+ */
+const Errors = Object.freeze({ "URL": 1, "CATEGORY": 2 });
 
-// add repo pop up
-// add action listener to add repo button
-document.getElementById('addRepo').addEventListener('click', function() {
-  // show popup
-  document.getElementById('addRepoModal').style.display = 'block';
-});
+window.onload = function () {
+  // add search action listener
+  document.getElementById('search').addEventListener('input', function () {
+    search(this.value);
+  });
 
-// add action listener for window (clicking anywhere)
-window.addEventListener('click', function(event) {
-  // if user clicked in the modal area (area around the popup) hide popup
-  if (event.target == document.getElementById('addRepoModal')) {
-    closeAddRepo();
-  }
-});
+  // add repo pop up
+  // add action listener to add repo button
+  document.getElementById('addRepo').addEventListener('click', function () {
+    // show popup
+    document.getElementById('addRepoModal').style.display = 'block';
+  });
 
-// add action listener to close add repo popup
-document.getElementById('cancelAddRepo').addEventListener('click', function() {
-  // close popup
-  closeAddRepo();
-});
+  // add action listener for window (clicking anywhere)
+  window.addEventListener('click', function (event) {
+    // if user clicked in the modal area (area around the popup) hide popup
+    if (event.target == document.getElementById('addRepoModal')) {
+      closeAddRepo();
+    }
+  });
 
-// add action listener to start repo scan
-document.getElementById('startRepoScan').addEventListener('click', function() {
-  // close popup
-  document.getElementById('addRepoModal').style.display = 'none';
-  // show loading popup
-});
+  // add action listener to close add repo popup
+  document.getElementById('cancelAddRepo').addEventListener('click', closeAddRepo());
 
-// add action listener to repo url input
-document.getElementById('repoLinkInput').addEventListener('input', function() {
-  // check if form is correctly filled
-  checkFormFilled();
-});
+  // add action listener to start repo scan
+  document.getElementById('startRepoScan').addEventListener('click', function () {
+    // close popup
+    document.getElementById('addRepoModal').style.display = 'none';
+    // show loading popup
+  });
 
-// add action listener to repo scan config selector
-document.getElementById('cbAllRules').addEventListener('change', function() {
-  // check if forenameFolderModalrm is correctly filled
-  checkFormFilled();
-});
+  document.getElementById('ruleSelector').addEventListener('change', checkFormFilled);
 
-// check if form is filled correctly and handle change
+  // add action listener to repo url input
+  document.getElementById('repoLinkInput').addEventListener('input', checkFormFilled);
+
+  // add action listener to repo scan config selector
+  document.getElementById('cbAllRules').addEventListener('change', checkFormFilled);
+};
+
+/**
+ * Check if form is filled correctly and handle change
+ */
+
 function checkFormFilled() {
   // get post repo scan button and form values
-  let postAddRepoButton = document.getElementById('startRepoScan');
-  let repoLink = document.getElementById('repoLinkInput').value;
+  let cBox = document.getElementById('cbAllRules');
+  let rulesList = document.getElementById('ruleSelector');
+  let repoLinkContainer = document.getElementById('repoLinkInput');
+  let repoLink = repoLinkContainer.value;
   // check if repo link is a valid url
   let urlValid = repoLink.match(/(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g);
   // enable submit button if url is valid
-  if (urlValid) {
+  console.log(urlValid);
+
+  if (urlValid || cBox.checked || rulesList.selectedIndex != -1) {
+    editForm(true);
+  }
+  if (urlValid == null) {
+    editForm(false, Errors.URL, 'The URL you have provided is invalid.');
+    return;
+  }
+  if (cBox.checked == true || rulesList.selectedIndex == -1) {
+    editForm(false, Errors.CATEGORY, 'Please select a category first.');
+    return;
+  }
+
+}
+
+/**
+ * A function to enable/disable the scan button and highlight alarming sections.
+ * @param {boolean} enable 
+ * True: Enables the button | False: Disables the button
+ * @param {string} tooltip 
+ * (Optional) Shows an error message when the mouse hovers on the disabled button
+ */
+function editForm(enable, err, tooltip = '') {
+  let postAddRepoButton = document.getElementById('startRepoScan');
+  let repoLinkContainer = document.getElementById('repoLinkInput');
+  let rulesList = document.getElementById('ruleSelector');
+  if (enable) {
     postAddRepoButton.disabled = false;
+    postAddRepoButton.title = tooltip;
     postAddRepoButton.classList.remove('disabledButton');
-    // else disable submit
+    repoLinkContainer.style.border = '1px solid black';
+    rulesList.style.border = '1px solid black';
   } else {
     postAddRepoButton.disabled = true;
+    postAddRepoButton.title = tooltip;
     postAddRepoButton.classList.add('disabledButton');
+    switch (err) {
+      case Errors.URL:
+        repoLinkContainer.style.border = '2px solid red';
+        break;
+      case Errors.CATEGORY:
+        rulesList.style.border = '2px solid red';
+        break;
+    }
   }
 }
 
@@ -71,5 +115,5 @@ function closeAddRepo() {
   document.getElementById('cbAllRules').checked = false;
   document.getElementById('cbSnippetModel').checked = false;
   document.getElementById('cbAllRules').checked = false;
-  checkFormFilled();
 }
+

--- a/ui/res/js/repos.js
+++ b/ui/res/js/repos.js
@@ -25,7 +25,7 @@ window.addEventListener('click', function (event) {
 });
 
 // add action listener to close add repo popup
-document.getElementById('cancelAddRepo').addEventListener('click', closeAddRepo());
+document.getElementById('cancelAddRepo').addEventListener('click', closeAddRepo);
 
 // add action listener to start repo scan
 document.getElementById('startRepoScan').addEventListener('click', function () {
@@ -62,7 +62,7 @@ function checkFormFilled() {
   if (urlValid == null) {
     editForm(false, Errors.URL, 'The URL you have provided is invalid.');
   }
-  if (cBox.checked == false && rulesList.selectedIndex == -1) {
+  if (!cBox.checked && rulesList.selectedIndex == -1) {
     editForm(false, Errors.CATEGORY, 'Please select a category first.');
   }
 

--- a/ui/res/js/repos.js
+++ b/ui/res/js/repos.js
@@ -4,7 +4,7 @@
  * - CATEGORY: The user must select one category.
  */
 const Errors = Object.freeze({ "URL": 1, "CATEGORY": 2 });
-
+checkFormFilled();
 // add search action listener
 document.getElementById('search').addEventListener('input', function () {
   search(this.value);

--- a/ui/res/js/repos.js
+++ b/ui/res/js/repos.js
@@ -4,45 +4,44 @@
  */
 const Errors = Object.freeze({ "URL": 1, "CATEGORY": 2 });
 
-window.onload = function () {
-  // add search action listener
-  document.getElementById('search').addEventListener('input', function () {
-    search(this.value);
-  });
+// add search action listener
+document.getElementById('search').addEventListener('input', function () {
+  search(this.value);
+});
 
-  // add repo pop up
-  // add action listener to add repo button
-  document.getElementById('addRepo').addEventListener('click', function () {
-    // show popup
-    document.getElementById('addRepoModal').style.display = 'block';
-  });
+// add repo pop up
+// add action listener to add repo button
+document.getElementById('addRepo').addEventListener('click', function () {
+  // show popup
+  document.getElementById('addRepoModal').style.display = 'block';
+});
 
-  // add action listener for window (clicking anywhere)
-  window.addEventListener('click', function (event) {
-    // if user clicked in the modal area (area around the popup) hide popup
-    if (event.target == document.getElementById('addRepoModal')) {
-      closeAddRepo();
-    }
-  });
+// add action listener for window (clicking anywhere)
+window.addEventListener('click', function (event) {
+  // if user clicked in the modal area (area around the popup) hide popup
+  if (event.target == document.getElementById('addRepoModal')) {
+    closeAddRepo();
+  }
+});
 
-  // add action listener to close add repo popup
-  document.getElementById('cancelAddRepo').addEventListener('click', closeAddRepo());
+// add action listener to close add repo popup
+document.getElementById('cancelAddRepo').addEventListener('click', closeAddRepo());
 
-  // add action listener to start repo scan
-  document.getElementById('startRepoScan').addEventListener('click', function () {
-    // close popup
-    document.getElementById('addRepoModal').style.display = 'none';
-    // show loading popup
-  });
+// add action listener to start repo scan
+document.getElementById('startRepoScan').addEventListener('click', function () {
+  // close popup
+  document.getElementById('addRepoModal').style.display = 'none';
+  // show loading popup
+});
 
-  document.getElementById('ruleSelector').addEventListener('change', checkFormFilled);
+document.getElementById('ruleSelector').addEventListener('change', checkFormFilled);
 
-  // add action listener to repo url input
-  document.getElementById('repoLinkInput').addEventListener('input', checkFormFilled);
+// add action listener to repo url input
+document.getElementById('repoLinkInput').addEventListener('input', checkFormFilled);
 
-  // add action listener to repo scan config selector
-  document.getElementById('cbAllRules').addEventListener('change', checkFormFilled);
-};
+// add action listener to repo scan config selector
+document.getElementById('cbAllRules').addEventListener('change', checkFormFilled);
+
 
 /**
  * Check if form is filled correctly and handle change

--- a/ui/res/js/repos.js
+++ b/ui/res/js/repos.js
@@ -84,15 +84,13 @@ function editForm(enable, err, tooltip = '') {
   let postAddRepoButton = document.getElementById('startRepoScan');
   let repoLinkContainer = document.getElementById('repoLinkInput');
   let rulesList = document.getElementById('ruleSelector');
+  postAddRepoButton.disabled = !enable;
+  postAddRepoButton.title = tooltip;
   if (enable) {
-    postAddRepoButton.disabled = false;
-    postAddRepoButton.title = tooltip;
     postAddRepoButton.classList.remove('disabledButton');
     repoLinkContainer.style.border = '1px solid black';
     rulesList.style.border = '1px solid black';
   } else {
-    postAddRepoButton.disabled = true;
-    postAddRepoButton.title = tooltip;
     postAddRepoButton.classList.add('disabledButton');
     switch (err) {
       case Errors.URL:

--- a/ui/res/js/repos.js
+++ b/ui/res/js/repos.js
@@ -1,11 +1,11 @@
 // add search action listener
-document.getElementById('search').addEventListener('input', function(event) {
+document.getElementById('search').addEventListener('input', function() {
   search(this.value);
 });
 
 // add repo pop up
 // add action listener to add repo button
-document.getElementById('addRepo').addEventListener('click', function(event) {
+document.getElementById('addRepo').addEventListener('click', function() {
   // show popup
   document.getElementById('addRepoModal').style.display = 'block';
 });
@@ -19,26 +19,26 @@ window.addEventListener('click', function(event) {
 });
 
 // add action listener to close add repo popup
-document.getElementById('cancelAddRepo').addEventListener('click', function(event) {
+document.getElementById('cancelAddRepo').addEventListener('click', function() {
   // close popup
   closeAddRepo();
 });
 
 // add action listener to start repo scan
-document.getElementById('startRepoScan').addEventListener('click', function(event) {
+document.getElementById('startRepoScan').addEventListener('click', function() {
   // close popup
   document.getElementById('addRepoModal').style.display = 'none';
   // show loading popup
 });
 
 // add action listener to repo url input
-document.getElementById('repoLinkInput').addEventListener('input', function(event) {
+document.getElementById('repoLinkInput').addEventListener('input', function() {
   // check if form is correctly filled
   checkFormFilled();
 });
 
 // add action listener to repo scan config selector
-document.getElementById('cbAllRules').addEventListener('change', function(event) {
+document.getElementById('cbAllRules').addEventListener('change', function() {
   // check if forenameFolderModalrm is correctly filled
   checkFormFilled();
 });

--- a/ui/res/js/repos.js
+++ b/ui/res/js/repos.js
@@ -38,7 +38,7 @@ document.getElementById('repoLinkInput').addEventListener('input', function(even
 });
 
 // add action listener to repo scan config selector
-document.getElementById('configSelector').addEventListener('change', function(event) {
+document.getElementById('cbAllRules').addEventListener('change', function(event) {
   // check if forenameFolderModalrm is correctly filled
   checkFormFilled();
 });
@@ -48,7 +48,7 @@ function checkFormFilled() {
   // get post repo scan button and form values
   var postAddRepoButton = document.getElementById('startRepoScan');
   var repoLink = document.getElementById('repoLinkInput').value;
-  var config = document.getElementById('configSelector').value;
+  var config = document.getElementById('cbAllRules').value;
   // check if repo link is a valid url
   var urlValid = repoLink.match(/(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g);
   // enable submit button if url is valid and config is set
@@ -69,6 +69,6 @@ function closeAddRepo() {
   // reset input
   document.getElementById('repoLinkInput').value = '';
   document.getElementById('ruleSelector').value = '';
-  document.getElementById('configSelector').checked = false;
+  document.getElementById('cbAllRules').checked = false;
   checkFormFilled();
 }

--- a/ui/res/js/repos.js
+++ b/ui/res/js/repos.js
@@ -1,6 +1,7 @@
 /**
- * URL: The URL is invalid.
- * CATEGORY: The user must select one category.
+ * @description An enum-like type to represent errors.
+ * - URL: The URL is invalid.
+ * - CATEGORY: The user must select one category.
  */
 const Errors = Object.freeze({ "URL": 1, "CATEGORY": 2 });
 
@@ -70,8 +71,12 @@ function checkFormFilled() {
 
 /**
  * A function to enable/disable the scan button and highlight alarming sections.
- * @param {boolean} enable 
- * True: Enables the button | False: Disables the button
+ * @param {boolean} enable Takes two possible values
+ * - True: Enables the button
+ * - False: Disables the button
+ * @param {enum} err Represents the type of error
+ * - URL: The URL is invalid.
+ * - CATEGORY: The user must select one category.
  * @param {string} tooltip 
  * (Optional) Shows an error message when the mouse hovers on the disabled button
  */

--- a/ui/res/js/repos.js
+++ b/ui/res/js/repos.js
@@ -61,11 +61,9 @@ function checkFormFilled() {
   }
   if (urlValid == null) {
     editForm(false, Errors.URL, 'The URL you have provided is invalid.');
-    return;
   }
   if (cBox.checked == true || rulesList.selectedIndex == -1) {
     editForm(false, Errors.CATEGORY, 'Please select a category first.');
-    return;
   }
 
 }

--- a/ui/res/js/repos.js
+++ b/ui/res/js/repos.js
@@ -56,8 +56,6 @@ function checkFormFilled() {
   // check if repo link is a valid url
   let urlValid = repoLink.match(/(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g);
   // enable submit button if url is valid
-  console.log(urlValid);
-
   if (urlValid || cBox.checked || rulesList.selectedIndex != -1) {
     editForm(true);
   }

--- a/ui/res/js/repos.js
+++ b/ui/res/js/repos.js
@@ -46,13 +46,12 @@ document.getElementById('cbAllRules').addEventListener('change', function(event)
 // check if form is filled correctly and handle change
 function checkFormFilled() {
   // get post repo scan button and form values
-  var postAddRepoButton = document.getElementById('startRepoScan');
-  var repoLink = document.getElementById('repoLinkInput').value;
-  var config = document.getElementById('cbAllRules').value;
+  let postAddRepoButton = document.getElementById('startRepoScan');
+  let repoLink = document.getElementById('repoLinkInput').value;
   // check if repo link is a valid url
-  var urlValid = repoLink.match(/(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g);
-  // enable submit button if url is valid and config is set
-  if (urlValid && config != '') {
+  let urlValid = repoLink.match(/(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g);
+  // enable submit button if url is valid
+  if (urlValid) {
     postAddRepoButton.disabled = false;
     postAddRepoButton.classList.remove('disabledButton');
     // else disable submit
@@ -69,6 +68,8 @@ function closeAddRepo() {
   // reset input
   document.getElementById('repoLinkInput').value = '';
   document.getElementById('ruleSelector').value = '';
+  document.getElementById('cbAllRules').checked = false;
+  document.getElementById('cbSnippetModel').checked = false;
   document.getElementById('cbAllRules').checked = false;
   checkFormFilled();
 }

--- a/ui/res/js/scan.js
+++ b/ui/res/js/scan.js
@@ -10,8 +10,8 @@ var scanRepo = function(e) {
     renderModal();
 };
 
-const scanRepoForm = document.forms["scan_repo"]
-scanRepoForm.addEventListener("submit", scanRepo, true)
+const scanRepoForm = document.forms["scan_repo"];
+scanRepoForm.addEventListener("submit", scanRepo, true);
 
 function renderModal() {
     //if modal already exists on page, just show it

--- a/ui/templates/discoveries.html
+++ b/ui/templates/discoveries.html
@@ -116,7 +116,7 @@
         <option value="{{rule.id}}">{{rule.regex}} | {{rule.category}}</option>
         {% endfor %}
       </select>
-      <input type="checkbox" id="configSelector" name="rid" value="all">Select all rules<br>
+      <input type="checkbox" id="cbAllRules" name="rid" value="all">Select all rules<br>
       <div class="formFooter">
         <span class="moreButtons">
           <input type="hidden" name="freshtoggle" value="on">

--- a/ui/templates/repos.html
+++ b/ui/templates/repos.html
@@ -56,7 +56,7 @@
       <span id="cancelAddRepo" class="close">&times;</span>
     </div>
     <form name="scan_repo" action="/scan_repo" method="post">
-      <input id="repoLinkInput" type="link" name="repolink" class="textInput" placeholder="GitHub Repo URL">
+      <input id="repoLinkInput" type="link" name="repolink" class="textInput" placeholder="GitHub Repo URL" required>
       <p class="formLabel">Select category :</p>
       <select id="ruleSelector" name="rule_to_use" class="formSelect" size="4">
         {% for cat in categories %}

--- a/ui/templates/repos.html
+++ b/ui/templates/repos.html
@@ -64,6 +64,8 @@
         {% endfor %}
       </select>
       <input type="checkbox" id="cbAllRules" name="rid" value="all">Select all rules<br>
+      <input type="checkbox" id="cbSnippetModel" name="rid" value="all">Use the Snippet model<br>
+      <input type="checkbox" id="cbAllRules" name="rid" value="all">Use the Path model<br>
       <div class="formFooter">
         <span class="moreButtons">
           <input type="hidden" name="freshtoggle" value="on">

--- a/ui/templates/repos.html
+++ b/ui/templates/repos.html
@@ -63,7 +63,7 @@
         <option value="{{cat}}">{{cat}}</option>
         {% endfor %}
       </select>
-      <input type="checkbox" id="configSelector" name="rid" value="all">Select all rules<br>
+      <input type="checkbox" id="cbAllRules" name="rid" value="all">Select all rules<br>
       <div class="formFooter">
         <span class="moreButtons">
           <input type="hidden" name="freshtoggle" value="on">

--- a/ui/templates/repos.html
+++ b/ui/templates/repos.html
@@ -58,14 +58,14 @@
     <form name="scan_repo" action="/scan_repo" method="post">
       <input id="repoLinkInput" type="link" name="repolink" class="textInput" placeholder="GitHub Repo URL">
       <p class="formLabel">Select category :</p>
-      <select id="ruleSelector" name="rid" class="formSelect" multiple>
+      <select id="ruleSelector" name="rule_to_use" class="formSelect" size="4">
         {% for cat in categories %}
         <option value="{{cat}}">{{cat}}</option>
         {% endfor %}
       </select>
-      <input type="checkbox" id="cbAllRules" name="rid" value="all">Select all rules<br>
-      <input type="checkbox" id="cbSnippetModel" name="rid" value="all">Use the Snippet model<br>
-      <input type="checkbox" id="cbAllRules" name="rid" value="all">Use the Path model<br>
+      <input type="checkbox" id="cbAllRules" name="rule_to_use" value="all">Select all rules<br>
+      <input type="checkbox" id="cbSnippetModel" name="snippetModel" value="snippet">Use the Snippet model<br>
+      <input type="checkbox" id="cbPathModel" name="pathModel" value="path">Use the Path model<br>
       <div class="formFooter">
         <span class="moreButtons">
           <input type="hidden" name="freshtoggle" value="on">


### PR DESCRIPTION
### Overview
It is now possible to scan a repository while making use of the Snippet and Path models. This PR also gives the user a better UI to interact with: expressive error messages will be shown whenever a scan's settings are not correctly set.

### Tagetted isssues
This PR is targeting these issues: https://github.com/SAP/credential-digger/issues/8, https://github.com/SAP/credential-digger/issues/15, https://github.com/SAP/credential-digger/issues/3 (3rd point only)

### Usage
Two checkboxes; one for the SnippetModel and the other for the PathModel, have been added to the scan window.

### Errors handling (UI/UX)
It is now impossible to run a scan if the repo URL is invalid or if the user did not select a category of rules (or the option to use all the existing categories).
The targetted input elements will be coloured in red and an expressive tooltip describing the error will appear when the mouse hovers on top of the disabled __scan__ button.


