### PR TITLE
Minor fix: Alternate between the states of the checkbox and the category selector.

### DIFF
--- a/ui/res/js/repos.js
+++ b/ui/res/js/repos.js
@@ -35,13 +35,22 @@ document.getElementById('startRepoScan').addEventListener('click', function () {
   // show loading popup
 });
 
-document.getElementById('ruleSelector').addEventListener('change', checkFormFilled);
+// add action listener to repo category selector
+document.getElementById('ruleSelector').addEventListener('change', function () {
+  //Disable the 'Use all rules' checkbox when a category is being manually selected.
+  document.getElementById('cbAllRules').checked = false;
+  checkFormFilled();
+});
 
 // add action listener to repo url input
 document.getElementById('repoLinkInput').addEventListener('input', checkFormFilled);
 
-// add action listener to repo scan config selector
-document.getElementById('cbAllRules').addEventListener('change', checkFormFilled);
+// add action listener to checkbox that selects all the rules
+document.getElementById('cbAllRules').addEventListener('change', function () {
+  //Select no category if this checkbox is 'Active'
+  document.getElementById('ruleSelector').selectedIndex = -1;
+  checkFormFilled();
+});
 
 
 /**


### PR DESCRIPTION
### Targetted issues
https://github.com/SAP/credential-digger/issues/3#issuecomment-680747770

#### Overview
This PR helps enhance the UX.

- Activating the 'Use all rules' checkbox clears the selections made on the 'Categories selector'
- Selecting an item from the 'Categories selector' disables the 'Use all rules' checkbox if it is active.
- Selecting no category at all && Not activating the checkbox will stop you from starting a scan.