### PR TITLE
Fix: Keep filtering FPs after refreshing the page

### DIFF
--- a/ui/res/js/discoveries.js
+++ b/ui/res/js/discoveries.js
@@ -3,6 +3,17 @@
 //var requests = [];
 var filterFPs = false;
 
+// It is mandatory to wait for the window to load before executing the
+// scripts 
+window.onload = function () {
+  filterFPs = sessionStorage.getItem('filterFPs');
+  if (filterFPs == 'None') {
+    filterFPs = false;
+  }
+  else if(filterFPs==true){
+    toggleFPs();
+  }
+};
 
 var tableRows = document.getElementsByClassName('tableRowContent');
 // add action listeners to table rows
@@ -23,7 +34,7 @@ function openExpandTableRow(tr) {
     // show if mouseover
     if (tr == tableRows[i]) {
       expandTableRows[i].style.display = 'table-cell';
-      tableRows[i].style.background = '#f5f5f5'
+      tableRows[i].style.background = '#f5f5f5';
       /*
       var markedSnippet = discovery[i].Snippet.replace(discovery[i].Content, '<span class="highlightedCode">' + discovery[i].Content + '</span>')
       document.getElementsByClassName('snippetCodeCell')[i].innerHTML = markedSnippet;
@@ -106,7 +117,10 @@ function closeAddRepo() {
 var allDiscoveries = document.getElementsByClassName('discoveryEntry');
 // Show/hide fp flag
 function switchFilter() {
+  //Swap the value of the filtering FLAG
   filterFPs = filterFPs ^ 1;
+  //Store the flag's value as long as the session is still running
+  sessionStorage.setItem('filterFPs', filterFPs);
   // Change color
   document.getElementById('showFPs').style.backgroundColor = '#0000ff';
   // Filter discoveries

--- a/ui/res/js/discoveries.js
+++ b/ui/res/js/discoveries.js
@@ -7,10 +7,7 @@ var filterFPs = false;
 // scripts 
 window.onload = function () {
   filterFPs = sessionStorage.getItem('filterFPs');
-  if (filterFPs == 'None') {
-    filterFPs = false;
-  }
-  else if(filterFPs==true){
+  if (filterFPs == true) {
     toggleFPs();
   }
 };


### PR DESCRIPTION
#### Targetted issue
https://github.com/SAP/credential-digger/issues/37

#### Overview
The FPs will get filtered even after the page gets refreshed. The problem was that the changes happen out-of-place and require the page to reload, hence losing all the settings. This would, in theory, have been avoided if we were using AJAX instead, or at least be less complicated to deal with for the changes happening actually in-place.

#### Fix
I have made use of the __window.sessionStorage__ in order to store the state of the flag (whether to filter the FPs or not) next time the window loads.

#### Limitation
A latency between loading the discoveries and filtering them may be noticed.

#### Future work
Should we reset the filtering setting back to default (filter = false) when the window closes?