### PR TITLE
Improve default rules

### DIFF
--- a/ui/backend/rules.yml
+++ b/ui/backend/rules.yml
@@ -1,41 +1,49 @@
+apiVersion: v1
 rules:
-
-  - regex: -----BEGIN RSA PRIVATE KEY-----[\r\n]+(?:\w+:.+)*[\s]*(?:[0-9a-zA-Z+\/=]{64,76}[\r\n]+)+[0-9a-zA-Z+\/=]+[\r\n]+-----END RSA PRIVATE KEY----
+  - definition: -----BEGIN [A-Z]+ PRIVATE KEY( BLOCK)?-----
     category: crypto_key
-    description: rsa private key
+    description: private key
 
-  - regex: -----BEGIN EC PRIVATE KEY-----[\r\n]+(?:\w+:.+)*[\s]*(?:[0-9a-zA-Z+\/=]{64,76}[\r\n]+)+[0-9a-zA-Z+\/=]+[\r\n]+-----END EC PRIVATE KEY----
-    category: crypto_key
-    description: ec private key
-
-  - regex: -----BEGIN PGP PRIVATE KEY BLOCK-----[\r\n]+(?:\w+:.+)*[\s]*(?:[0-9a-zA-Z+\/=]{64,76}[\r\n]+)+[0-9a-zA-Z+\/=]+[\r\n]+-----END PGP PRIVATE KEY BLOCK----
-    category: crypto_key
-    description: pgp private key
-
-  - regex: -----BEGIN PRIVATE KEY-----[\r\n]+(?:\w+:.+)*[\s]*(?:[0-9a-zA-Z+\/=]{64,76}[\r\n]+)+[0-9a-zA-Z+\/=]+[\r\n]+-----END PRIVATE KEY----
-    category: crypto_key
-    description: generic private key
-
-  - regex: ((?:\?|\&|\"|\')(?:access_token)(?:\"|\')?\s*(?:=|:))
-    category: access token
-    description: generic access token
-
-  - regex: EAACEdEose0cBA[0-9A-Za-z]+
+  - definition: EAACEdEose0cBA[0-9A-Za-z]+
     category: token
-    description: facebook access token rule
+    description: fb access token
 
-  - regex: AIza[0-9A-Za-z\-_]{35}
+  - definition: '[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
     category: token
     description: google token
 
-  - regex: '[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
-    category: token
-    description: google token
-
-  - regex: AKIA[0-9A-Z]{16}
+  - definition: AKIA[0-9A-Z]{16}
     category: token
     description: amazon token
 
-  - regex: sshpass|password|pwd|passwd|pass
-    category: password
-    description: password keywords
+  - definition: '[0-9a-fA-F]{7}\.[0-9a-fA-F]{32}'
+    category: token
+    description: instagram token
+
+  - definition: '[1-9][0-9]+-[0-9a-zA-Z]{40}'
+    category: token
+    description: twitter access token
+
+  - definition: '[A-Za-z0-9_]{21}--[A-Za-z0-9_]{8}'
+    category: token
+    description: GCP API key
+
+  - definition: 'xox.-[0-9]{12}-[0-9]{12}-[0-9a-zA-Z]{24}'
+    category: token
+    description: Slack API key
+
+  - definition: 'access_token,production$[0-9a-z]{161[0-9a,]{32}'
+    category: token
+    description: paypal acess token
+
+  - definition: 'amzn.mws]{8}-[0-9a-f]{4}-10-9a-f1{4}-[0-9a,]{4}-[0-9a-f]{12}'
+    category: token
+    description: AMS Auth Token
+
+  - definition: 'key-[0-9a-zA-Z]{32}'
+    category: token
+    description: Mailgun API key
+
+  - definition: '[0-9a-f]{32}-us[0-9]{1,2}'
+    category: token
+    description: MailChimp API key

--- a/ui/backend/rules.yml
+++ b/ui/backend/rules.yml
@@ -1,49 +1,52 @@
-apiVersion: v1
 rules:
-  - definition: -----BEGIN [A-Z]+ PRIVATE KEY( BLOCK)?-----
+  - regex: -----BEGIN [A-Z]+ PRIVATE KEY( BLOCK)?-----
     category: crypto_key
     description: private key
 
-  - definition: EAACEdEose0cBA[0-9A-Za-z]+
+  - regex: EAACEdEose0cBA[0-9A-Za-z]+
     category: token
     description: fb access token
 
-  - definition: '[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
+  - regex: '[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
     category: token
     description: google token
 
-  - definition: AKIA[0-9A-Z]{16}
+  - regex: AKIA[0-9A-Z]{16}
     category: token
     description: amazon token
 
-  - definition: '[0-9a-fA-F]{7}\.[0-9a-fA-F]{32}'
+  - regex: '[0-9a-fA-F]{7}\.[0-9a-fA-F]{32}'
     category: token
     description: instagram token
 
-  - definition: '[1-9][0-9]+-[0-9a-zA-Z]{40}'
+  - regex: '[1-9][0-9]+-[0-9a-zA-Z]{40}'
     category: token
     description: twitter access token
 
-  - definition: '[A-Za-z0-9_]{21}--[A-Za-z0-9_]{8}'
+  - regex: '[A-Za-z0-9_]{21}--[A-Za-z0-9_]{8}'
     category: token
     description: GCP API key
 
-  - definition: 'xox.-[0-9]{12}-[0-9]{12}-[0-9a-zA-Z]{24}'
+  - regex: 'xox.-[0-9]{12}-[0-9]{12}-[0-9a-zA-Z]{24}'
     category: token
     description: Slack API key
 
-  - definition: 'access_token,production$[0-9a-z]{161[0-9a,]{32}'
+  - regex: 'access_token,production$[0-9a-z]{161[0-9a,]{32}'
     category: token
     description: paypal acess token
 
-  - definition: 'amzn.mws]{8}-[0-9a-f]{4}-10-9a-f1{4}-[0-9a,]{4}-[0-9a-f]{12}'
+  - regex: 'amzn.mws]{8}-[0-9a-f]{4}-10-9a-f1{4}-[0-9a,]{4}-[0-9a-f]{12}'
     category: token
     description: AMS Auth Token
 
-  - definition: 'key-[0-9a-zA-Z]{32}'
+  - regex: 'key-[0-9a-zA-Z]{32}'
     category: token
     description: Mailgun API key
 
-  - definition: '[0-9a-f]{32}-us[0-9]{1,2}'
+  - regex: '[0-9a-f]{32}-us[0-9]{1,2}'
     category: token
     description: MailChimp API key
+
+  - regex: sshpass|password|pwd|passwd|pass
+    category: password
+    description: password keywords

--- a/ui/backend/rules.yml
+++ b/ui/backend/rules.yml
@@ -23,22 +23,6 @@ rules:
     category: token
     description: twitter access token
 
-  - regex: '[A-Za-z0-9_]{21}--[A-Za-z0-9_]{8}'
-    category: token
-    description: GCP API key
-
-  - regex: 'xox.-[0-9]{12}-[0-9]{12}-[0-9a-zA-Z]{24}'
-    category: token
-    description: Slack API key
-
-  - regex: 'access_token,production$[0-9a-z]{161[0-9a,]{32}'
-    category: token
-    description: paypal acess token
-
-  - regex: 'amzn.mws]{8}-[0-9a-f]{4}-10-9a-f1{4}-[0-9a,]{4}-[0-9a-f]{12}'
-    category: token
-    description: AMS Auth Token
-
   - regex: 'key-[0-9a-zA-Z]{32}'
     category: token
     description: Mailgun API key


### PR DESCRIPTION

**Combined private key rules into single rule**
```yaml
  - definition: -----BEGIN [A-Z]+ PRIVATE KEY( BLOCK)?-----
    category: crypto_key
    description: private key
```
This reduces the cost of matching the `[\r\n]+(?:\w+:.+)*[\s]*(?:[0-9a-zA-Z+\/=]{64,76}[\r\n]+)+[0-9a-zA-Z+\/=]+[\r\n]+` group (in most scenarios the beginning of a private key block would automatically be followed by the corresponding key). The trade-off between cost and precision can be further discussed.

**Removed generic rules**
```yaml
  - regex: sshpass|password|pwd|passwd|pass
    category: password
    description: password keywords
```
This rule often leads to a lot of false positive due to it being completely context insensitive, for example;
- `passed` is matched because it contains `pass` 
- in a key-value file, it would even match when the value is empty 
These kind of rules should rather be delegated to the models and not regexes.

```yaml
  - regex: ((?:\?|\&|\"|\')(?:access_token)(?:\"|\')?\s*(?:=|:))
    category: access token
    description: generic access token
```
The same can be said about the above rule. It lacks the context for proper matching.

**Added some more distinct API key matching rules**
```yaml
  - definition: 'xox.-[0-9]{12}-[0-9]{12}-[0-9a-zA-Z]{24}'
    category: token
    description: Slack API key

  - definition: 'access_token,production$[0-9a-z]{161[0-9a,]{32}'
    category: token
    description: paypal acess token

  - definition: 'amzn.mws]{8}-[0-9a-f]{4}-10-9a-f1{4}-[0-9a,]{4}-[0-9a-f]{12}'
    category: token
    description: AMS Auth Token

  - definition: 'key-[0-9a-zA-Z]{32}'
    category: token
    description: Mailgun API key

  - definition: '[0-9a-f]{32}-us[0-9]{1,2}'
    category: token
    description: MailChimp API key
```
These are sets of distinct rules that could be added to improve default leak discovery.

Signed-off-by: Quoc Trung Hoang <quoc-trung.hoang@etu.utc.fr>