### PR TITLE
Fix UI bugs + new features + JS refactoring

### DIFF
--- a/ui/res/js/discoveries.js
+++ b/ui/res/js/discoveries.js
@@ -1,5 +1,6 @@
-var filterFPs = false;
-
+let filterFPs = false;
+// The list of the categories to skip while filtering.
+let categoriesToSkip = [];
 // It is mandatory to wait for the window to load before executing the
 // scripts
 window.onload = function () {
@@ -50,58 +51,31 @@ window.addEventListener('click', function (event) {
   if (event.target == document.getElementById('deleteRepoModal')) {
     document.getElementById('deleteRepoModal').style.display = 'none';
   }
+  if (event.target == document.getElementById('addRepoModal')) {
+    closeAddRepo();
+  }
+
 });
+
 document.getElementById('cancelDeleteRepo').addEventListener('click', function (event) {
   // hide popup
   document.getElementById('deleteRepoModal').style.display = 'none';
 });
 
+document.getElementById('cancelAddRepo').addEventListener('click', closeAddRepo);
 
 // New scan
 // add action listener to scan repo button
 document.getElementById('newScan').addEventListener('click', function (event) {
   // Show popup
   document.getElementById('addRepoModal').style.display = 'block';
+  document.getElementById('repoLinkInput').value = window.name;
+  checkFormFilled();
 });
-// Add action listener for window (clicking anywhere)
-window.addEventListener('click', function (event) {
-  // if user clicks in the modal area (area around the popup) hide popup
-  if (event.target == document.getElementById('addRepoModal')) {
-    closeAddRepo();
-  }
-});
-// add action listener to close scan repo popup
-document.getElementById('cancelAddRepo').addEventListener('click', function (event) {
-  // close popup
-  closeAddRepo();
-});
-// add action listener to start repo scan
-document.getElementById('startRepoScan').addEventListener('click', function (event) {
+document.getElementById('startRepoScan').addEventListener('click', function () {
   // close popup
   document.getElementById('addRepoModal').style.display = 'none';
-  // show loading popup
 });
-// add action listener to repo scan config selector
-document.getElementById('cbAllRules').addEventListener('change', function (event) {
-  // check if form is correctly filled
-  var config = document.getElementById('cbAllRules').value;
-  var postAddRepoButton = document.getElementById('startRepoScan');
-  if (config != '') {
-    postAddRepoButton.disabled = false;
-    postAddRepoButton.classList.remove('disabledButton');
-    // else disable submit
-  } else {
-    postAddRepoButton.disabled = true;
-    postAddRepoButton.classList.add('disabledButton');
-  }
-});
-// close scan repo pop up
-function closeAddRepo() {
-  // hide popup
-  document.getElementById('addRepoModal').style.display = 'none';
-  // reset input
-}
-
 var allDiscoveries = document.getElementsByClassName('discoveryEntry');
 // Show/hide fp flag
 function switchFilter() {
@@ -128,4 +102,68 @@ function toggleFPs() {
   document.getElementById('discoveriesCounter').innerHTML = filterFPs ?
     `${allDiscoveries.length} discoveries found (${countDiscoveries} false positives are hidden)` :
     `${allDiscoveries.length} discoveries found`;
+}
+
+// add action listener to checkbox that selects all the rules
+document.getElementById('cbAllRules').addEventListener('change', function () {
+  //Select no category if this checkbox is 'Active'
+  document.getElementById('ruleSelector').selectedIndex = -1;
+  checkFormFilled();
+});
+
+// add action listener to repo category selector
+document.getElementById('ruleSelector').addEventListener('change', function () {
+  //Disable the 'Use all rules' checkbox when a category is being manually selected.
+  document.getElementById('cbAllRules').checked = false;
+  checkFormFilled();
+});
+
+// A self-invoking function to assign functions to the filtering buttons
+(function catFilteringInit() {
+  let filteringButtons = document.getElementsByClassName('categoryToggle');
+  for (let i = 0; i < filteringButtons.length; i++) {
+    let buttonsContainer = filteringButtons[i];
+    buttonsContainer.onclick = clickedButton => {
+      let button = clickedButton.target;
+      const category = button.innerText;
+      const indexOfCat = categoriesToSkip.indexOf(category);
+      if (indexOfCat > -1) {
+        // Disable the filter
+        categoriesToSkip.splice(indexOfCat, 1);
+        button.style.background = 'white';
+      }
+      else {
+        // Enable the filter
+        categoriesToSkip.push(category);
+        button.style.background = 'dodgerblue';
+      }
+      filterCategories();
+    };
+  }
+
+}());
+
+/**
+ * A function to filter the discoveries based on their categories.
+ */
+function filterCategories() {
+  // No categories to filter
+  if (categoriesToSkip.length == 0) {
+    for (let i = 0; i < allDiscoveries.length; i++) {
+      let discovery = allDiscoveries[i];
+      discovery.style.display = '';
+    }
+  }
+  else {
+    for (let i = 0; i < allDiscoveries.length; i++) {
+      let discovery = allDiscoveries[i];
+      /**
+       * Ninja code : skip is a boolean. it is set to true if this discovery will be ignored
+       * false, otherwise.
+       */
+      const skip = (categoriesToSkip.indexOf(discovery.children[0].valueOf().innerText) == -1);
+      discovery.style.display = skip ? 'none' : '';
+    }
+  }
+
 }

--- a/ui/res/js/repos.js
+++ b/ui/res/js/repos.js
@@ -1,10 +1,10 @@
-/**
- * @description An enum-like type to represent errors.
- * - URL: The URL is invalid.
- * - CATEGORY: The user must select one category.
- */
-const Errors = Object.freeze({ "URL": 1, "CATEGORY": 2 });
-checkFormFilled();
+
+let listOfRepos;
+window.onload = function () {
+  listOfRepos = document.getElementsByClassName('repo tableRowContent');
+  checkFormFilled();
+};
+
 // add search action listener
 document.getElementById('search').addEventListener('input', function () {
   search(this.value);
@@ -54,72 +54,29 @@ document.getElementById('cbAllRules').addEventListener('change', function () {
 
 
 /**
- * Check if form is filled correctly and handle change
+ * Searches for repos that have an URL that contains the __text__ argument.
+ * @param {string} text This argument is used to find all the repos that have an URL that matches its value.
+ * @param {boolean} hideNotMatching If set to __false__, the matching repos will not be removed from the UI.
+ * @returns Returns an object that has two attributes
+ * -  __text__: Equals the textual value that has been used to perform the search
+ * -  __indices__: An array that contains the indices of the matching repos. These indices can be used to access
+ *                the repo from the __listOfRepos__ array.
  */
-
-function checkFormFilled() {
-  // get HTML elements
-  let cBox = document.getElementById('cbAllRules');
-  let rulesList = document.getElementById('ruleSelector');
-  let repoLinkContainer = document.getElementById('repoLinkInput');
-  let repoLink = repoLinkContainer.value;
-  // check if repo link is a valid url
-  let urlValid = repoLink.match(/(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g);
-  // check whether the form is correctly filled or not.
-  if (urlValid || cBox.checked || rulesList.selectedIndex != -1) {
-    editForm(true);
-  }
-  if (urlValid == null) {
-    editForm(false, Errors.URL, 'The URL you have provided is invalid.');
-  }
-  if (!cBox.checked && rulesList.selectedIndex == -1) {
-    editForm(false, Errors.CATEGORY, 'Please select a category first.');
-  }
-
-}
-
-/**
- * A function to enable/disable the scan button and highlight alarming sections.
- * @param {boolean} enable Takes two possible values
- * - True: Enables the button
- * - False: Disables the button
- * @param {enum} err Represents the type of error
- * - URL: The URL is invalid.
- * - CATEGORY: The user must select one category.
- * @param {string} tooltip
- * (Optional) Shows an error message when the mouse hovers on the disabled button
- */
-function editForm(enable, err, tooltip = '') {
-  let postAddRepoButton = document.getElementById('startRepoScan');
-  let repoLinkContainer = document.getElementById('repoLinkInput');
-  let rulesList = document.getElementById('ruleSelector');
-  postAddRepoButton.disabled = !enable;
-  postAddRepoButton.title = tooltip;
-  if (enable) {
-    postAddRepoButton.classList.remove('disabledButton');
-    repoLinkContainer.style.border = '1px solid black';
-    rulesList.style.border = '1px solid black';
-  } else {
-    postAddRepoButton.classList.add('disabledButton');
-    switch (err) {
-      case Errors.URL:
-        repoLinkContainer.style.border = '2px solid red';
-        break;
-      case Errors.CATEGORY:
-        rulesList.style.border = '2px solid red';
-        break;
+function search(text, hideNotMatching = true) {
+  let listOfMatches = {
+    text: text,
+    indices: []
+  };
+  text = text.toLowerCase();
+  for (let i = 0; i < listOfRepos.length; i++) {
+    let element = listOfRepos[i];
+    if (!element.textContent.toLowerCase().includes(text)) {
+      if (hideNotMatching) { element.style.display = 'none'; }
+    }
+    else {
+      element.style.display = '';
+      listOfMatches.indices.push(i);
     }
   }
-}
-
-// close add repo pop up
-function closeAddRepo() {
-  // hide popup
-  document.getElementById('addRepoModal').style.display = 'none';
-  // reset input
-  document.getElementById('repoLinkInput').value = '';
-  document.getElementById('ruleSelector').value = '';
-  document.getElementById('cbAllRules').checked = false;
-  document.getElementById('cbSnippetModel').checked = false;
-  document.getElementById('cbAllRules').checked = false;
-}
+  return listOfMatches;
+} 

--- a/ui/res/js/scanForm.js
+++ b/ui/res/js/scanForm.js
@@ -1,0 +1,76 @@
+
+/**
+ * @description An enum-like type to represent errors.
+ * - URL: The URL is invalid.
+ * - CATEGORY: The user must select one category.
+ */
+const Errors = Object.freeze({ "URL": 1, "CATEGORY": 2 });
+
+/**
+ * Check if form is filled correctly and handle change
+ */
+function checkFormFilled() {
+    // get HTML elements
+    let cBox = document.getElementById('cbAllRules');
+    let rulesList = document.getElementById('ruleSelector');
+    let repoLinkContainer = document.getElementById('repoLinkInput');
+    let repoLink = repoLinkContainer.value;
+    // check if repo link is a valid url
+    let urlValid = repoLink.match(/(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g);
+    // check whether the form is correctly filled or not.
+    if (urlValid || cBox.checked || rulesList.selectedIndex != -1) {
+        editForm(true);
+    }
+    if (urlValid == null) {
+        editForm(false, Errors.URL, 'The URL you have provided is invalid.');
+    }
+    if (!cBox.checked && rulesList.selectedIndex == -1) {
+        editForm(false, Errors.CATEGORY, 'Please select a category first.');
+    }
+}
+
+/**
+ * A function to enable/disable the scan button and highlight alarming sections.
+ * @param {boolean} enable Takes two possible values
+ * - True: Enables the button
+ * - False: Disables the button
+ * @param {enum} err Represents the type of error
+ * - URL: The URL is invalid.
+ * - CATEGORY: The user must select one category.
+ * @param {string} tooltip
+ * (Optional) Shows an error message when the mouse hovers on the disabled button
+ */
+function editForm(enable, err, tooltip = '') {
+    let postAddRepoButton = document.getElementById('startRepoScan');
+    let repoLinkContainer = document.getElementById('repoLinkInput');
+    let rulesList = document.getElementById('ruleSelector');
+    postAddRepoButton.disabled = !enable;
+    postAddRepoButton.title = tooltip;
+    if (enable) {
+        postAddRepoButton.classList.remove('disabledButton');
+        repoLinkContainer.style.border = '1px solid black';
+        rulesList.style.border = '1px solid black';
+    } else {
+        postAddRepoButton.classList.add('disabledButton');
+        switch (err) {
+            case Errors.URL:
+                repoLinkContainer.style.border = '2px solid red';
+                break;
+            case Errors.CATEGORY:
+                rulesList.style.border = '2px solid red';
+                break;
+        }
+    }
+}
+
+// close add repo pop up
+function closeAddRepo() {
+    // hide popup
+    document.getElementById('addRepoModal').style.display = 'none';
+    // reset input
+    document.getElementById('repoLinkInput').value = '';
+    document.getElementById('ruleSelector').value = '';
+    document.getElementById('cbAllRules').checked = false;
+    document.getElementById('cbSnippetModel').checked = false;
+    document.getElementById('cbAllRules').checked = false;
+}

--- a/ui/server.py
+++ b/ui/server.py
@@ -64,9 +64,11 @@ def discoveries():
     # There may be missing ids. Restructure as a dict
     # There may be no mapping between list index and rule id
     # Not very elegant, but avoid IndexError
+    cat = set()
     rulesdict = {}
     for rule in rules:
         rulesdict[rule['id']] = rule
+        cat.add(rule['category'])
 
     categories_found = set()
 
@@ -80,7 +82,7 @@ def discoveries():
                            discoveries=discoveries,
                            lendiscoveries=len(discoveries),
                            all_categories=categories_found,
-                           ruleslist=rules)
+                           categories=list(cat))
 
 
 @app.route('/rules')
@@ -117,17 +119,22 @@ def scan_repo():
     rulesToUse = request.form.get('rule_to_use')
     useSnippetModel = request.form.get('snippetModel')
     usePathModel = request.form.get('pathModel')
+    # If the form does not contain the 'Force' checkbox,
+    # then 'forceScan' will be set to False; thus, ignored.
+    forceScan = request.form.get('forceScan') == 'force'
+
     # Set up models
     models = []
     if usePathModel == 'path':
         models.append('PathModel')
     if useSnippetModel == 'snippet':
         models.append('SnippetModel')
+    app.logger.info(repolink)
     # Scan
     if rulesToUse == 'all':
-        c.scan(repolink, models=models)
+        c.scan(repolink, models=models, force=forceScan)
     else:
-        c.scan(repolink, models=models, category=rulesToUse)
+        c.scan(repolink, models=models, category=rulesToUse, force=forceScan)
     return redirect('/')
 
 

--- a/ui/server.py
+++ b/ui/server.py
@@ -129,7 +129,7 @@ def scan_repo():
         models.append('PathModel')
     if useSnippetModel == 'snippet':
         models.append('SnippetModel')
-    app.logger.info(repolink)
+        
     # Scan
     if rulesToUse == 'all':
         c.scan(repolink, models=models, force=forceScan)

--- a/ui/templates/discoveries.html
+++ b/ui/templates/discoveries.html
@@ -5,7 +5,7 @@
 <div class="topicHeaderWrapper">
   <h1 class="topicH1"> Discoveries</h1>
   <span class="moreButtons moreButtonsDiscoveries">
-    <button id="newScan">New Scan</button>
+    <button id="newScan">Rescan</button>
     <button id="deleteRepo">Delete Repo</button>
     <button id="showFPs" onclick="switchFilter()">Hide FPs</button>
   </span>
@@ -17,15 +17,15 @@
 <div class="filtersWrapper">
   {% for cat in all_categories %}
   <button class="categoryToggle filters">
-    <span>{{cat}}</span>
+    {{cat}}
   </button>
   {% endfor %}
 </div>
 <table id="discoveriesTable">
   <colgroup>
-    <col width="180px"/>
-    <col width="680px"/>
-    <col width="140px"/>
+    <col width="180px" />
+    <col width="680px" />
+    <col width="140px" />
   </colgroup>
 
   <!-- Header -->
@@ -38,46 +38,52 @@
   <!-- Content (filled with discoveries info) -->
   {% for discovery in discoveries %}
 
-    <tr class="discoveryEntry tableRowContent discoveryGroup">
-      <td>{{discovery.cat}}</td>
-      <td><a class="tableRowContentLink" href="{{discovery.repo_url}}/blob/{{discovery.commit_id}}/{{discovery.file_name}}">{{discovery.file_name}}</a></td>
-      <td>{{discovery.state}}</td>
-    </tr>
+  <tr class="discoveryEntry tableRowContent discoveryGroup">
+    <td>{{discovery.cat}}</td>
+    <td><a class="tableRowContentLink"
+        href="{{discovery.repo_url}}/blob/{{discovery.commit_id}}/{{discovery.file_name}}">{{discovery.file_name}}</a>
+    </td>
+    <td>{{discovery.state}}</td>
+  </tr>
 
-    <tr class="tableRowHover discoveryGroup">
-      <td colspan="3" class="expandTableRow">
-        <table class="snippetTable">
+  <tr class="tableRowHover discoveryGroup">
+    <td colspan="3" class="expandTableRow">
+      <table class="snippetTable">
 
-          <!-- Commit reference -->
-          <tr>
-            <td colspan="3">
-              <div class="snippetHeader">
-                <span>Commit: {{discovery.commit_id}}</span>
-                <span class="moreButtons">
-                  <a class="linkButton" href="{{discovery.repo_url}}/commit/{{discovery.commit_id}}/" target="_blank">Open Commit</a>
-                </span>
-              </div>
-            </td>
-          </tr>
+        <!-- Commit reference -->
+        <tr>
+          <td colspan="3">
+            <div class="snippetHeader">
+              <span>Commit: {{discovery.commit_id}}</span>
+              <span class="moreButtons">
+                <a class="linkButton" href="{{discovery.repo_url}}/commit/{{discovery.commit_id}}/" target="_blank">Open
+                  Commit</a>
+              </span>
+            </div>
+          </td>
+        </tr>
 
-          <!-- Snippet -->
-          <tr class="snippetCodeLine" valign="top">
-            <td class="snippetLineCell">{{discovery.snippet}}</td>
-            <td class="snippetCodeCell"></td>
-          </tr>
-        </table>
+        <!-- Snippet -->
+        <tr class="snippetCodeLine" valign="top">
+          <td class="snippetLineCell">{{discovery.snippet}}</td>
+          <td class="snippetCodeCell"></td>
+        </tr>
+      </table>
 
-        <!-- Flag buttons -->
-        <div class="discoveryStateButtonWrapper">
-          <p class="formLabel flagsText"></p>
-          <span class="moreButtons moreButtonsAdressed">
-            <button onclick="location.href = '/fp/{{discovery.id}}?url={{discovery.repo_url}}'" class="">False positive</button>
-            <button onclick="location.href ='/addressing/{{discovery.id}}?url={{discovery.repo_url}}'" class="">Adress it</button>
-            <button onclick="location.href ='/not_relevant/{{discovery.id}}?url={{discovery.repo_url}}'" class="">Not relevant anymore</button>
-          </span>
-        </div>
-      </td>
-    </tr>
+      <!-- Flag buttons -->
+      <div class="discoveryStateButtonWrapper">
+        <p class="formLabel flagsText"></p>
+        <span class="moreButtons moreButtonsAdressed">
+          <button onclick="location.href = '/fp/{{discovery.id}}?url={{discovery.repo_url}}'" class="">False
+            positive</button>
+          <button onclick="location.href = '/addressing/{{discovery.id}}?url={{discovery.repo_url}}'" class="">Adress
+            it</button>
+          <button onclick="location.href = '/not_relevant/{{discovery.id}}?url={{discovery.repo_url}}'" class="">Not
+            relevant anymore</button>
+        </span>
+      </div>
+    </td>
+  </tr>
 
   {% endfor %}
 </table>
@@ -105,18 +111,23 @@
 <div id="addRepoModal" class="modal">
   <div class="modal-content">
     <div class="topicHeaderWrapper">
-      <h1 class="topicH1">Scan new Repo</h1>
+      <h1 class="topicH1">Rescanning the <a href="{{url}}" title="{{url}}">repo</a></h1><br>
       <span id="cancelAddRepo" class="close">&times;</span>
     </div>
     <form name="scan_repo" action="/scan_repo" method="post">
-      <input id="repoLinkInput" type="link" name="repolink" class="textInput" value="{{url}}">
-      <p class="formLabel">Select rules (Regex | category):</p>
-      <select id="folderSelector" name="rid" class="formSelect" multiple>
-        {% for rule in ruleslist %}
-        <option value="{{rule.id}}">{{rule.regex}} | {{rule.category}}</option>
+      <input id="repoLinkInput" type="link" name="repolink" class="textInput" placeholder="GitHub Repo URL"
+        style='display:none;'>
+      <p class="formLabel">Select category :</p>
+      <select id="ruleSelector" name="rule_to_use" class="formSelect" size="4">
+        {% for cat in categories %}
+        <option value="{{cat}}">{{cat}}</option>
         {% endfor %}
       </select>
-      <input type="checkbox" id="cbAllRules" name="rid" value="all">Select all rules<br>
+      <input type="checkbox" id="cbAllRules" name="rule_to_use" value="all">Select all rules<br>
+      <input type="checkbox" id="cbPathModel" name="pathModel" value="path">Use the Path model<br>
+      <input type="checkbox" id="cbSnippetModel" name="snippetModel" value="snippet">Use the Snippet model<br>
+      <input type="checkbox" id="cbForce" name="forceScan" value="force" title="Scan the repo again completely from scratch"
+        >Force scan<br>
       <div class="formFooter">
         <span class="moreButtons">
           <input type="hidden" name="freshtoggle" value="on">
@@ -127,7 +138,10 @@
   </div>
 </div>
 
-
+<script>
+  window.name = "{{url}}";
+</script>
+<script src="/res/js/scanForm.js"></script>
 <script src="/res/js/discoveries.js"></script>
 <script src="/res/js/scan.js"></script>
 {% endblock %}

--- a/ui/templates/repos.html
+++ b/ui/templates/repos.html
@@ -75,6 +75,7 @@
     </form>
   </div>
 </div>
+<script src="/res/js/scanForm.js"></script>
 <script src="/res/js/repos.js"></script>
 <script src="/res/js/scan.js"></script>
 {% endblock %}


### PR DESCRIPTION
### Targetted issues

- https://github.com/SAP/credential-digger/issues/3 (points: 4 + 5)
- https://github.com/SAP/credential-digger/issues/36
- https://github.com/SAP/credential-digger/issues/36
- https://github.com/SAP/credential-digger/issues/42 (closing the following PR: https://github.com/SAP/credential-digger/pull/43, as a consequence)

## Fixes and new features
### Re-scan a repo using the categories instead of RAW rules
It is now possible to re-scan the selected repo using the categories.
### Re-scan a repo using the __Force__ mode
A checkbox to decide whether to scan a repo using the Force mode or not has been added to the (re)scan window.
### Search for repos using the search bar
The user can make use of the search bar on the main page to search for repos.
### Filter discoveries based on their categories
It is now possible to filter categories based on their categories using the buttons on the top-left of the window.
![image](https://user-images.githubusercontent.com/9027148/92165650-a8279600-ee37-11ea-945e-0c8c43e0a4ce.png)
(In this example, the user will only see the discoveries that are under the  `access token` category; of course, clicking on it again will disable the filter)

## Javascript & Redundant code
The javascript code has been optimized: got rid of redundant code & refactored multiple parts of it.
Both the `repos` and `discoveries` windows are making use of the same `scan modal`, that said, I did collect all the code chunks that manage it within a new `scanForm.js` file, in which are contained all the functions that are needed to exploit the scan widget.

### Future work
We may consider using [web-components](https://developer.mozilla.org/en-US/docs/Web/Web_Components) in a future PR.
