### PR TITLE
Add rules from CLI: One step closer to plug-and-play

### DIFF
--- a/credentialdigger/__init__.py
+++ b/credentialdigger/__init__.py
@@ -1,5 +1,6 @@
 from .client import Client
 from .client_postgres import PgClient
 from .client_sqlite import SqliteClient
+from .add_rules import add_rules
 from .download import download
 from .scan import scan

--- a/credentialdigger/__main__.py
+++ b/credentialdigger/__main__.py
@@ -3,15 +3,13 @@ import logging
 if __name__ == "__main__":
     import plac
     import sys
-    from credentialdigger import download, scan
+    from credentialdigger import add_rules, download, scan
 
-    commands = {'download': download, 'scan': scan}
+    commands = {'add_rules': add_rules, 'download': download, 'scan': scan}
     available_comamnds = f'{", ".join(commands)}'
     if len(sys.argv) == 1:
-        logging.error(
-            f'You did not call any command.\n\
-            Available commands: {available_comamnds}'
-        )
+        logging.error(f'You did not call any command.\n\
+            Available commands: {available_comamnds}')
         exit()
     command = sys.argv.pop(1)
     sys.argv[0] = f'credentialdigger {command}'

--- a/credentialdigger/add_rules.py
+++ b/credentialdigger/add_rules.py
@@ -1,0 +1,85 @@
+"""
+The 'add_rules' modules add scanning rules from a file to the database.
+This module supports both Sqlite & Postegres databases.
+NOTE: Please make sure that the environment variables are exported.
+
+This command takes multiple arguments:
+path_to_rules       <Required> The path of the file that contains the rules.
+
+--sqlite DB_PATH    <Optional> If specified, use the sqlite client and
+                        the db passed as argument (otherwise use postgres)
+
+Usage:
+python -m credentialdigger add_rules /path/rules.yml
+
+"""
+import argparse
+import logging
+import os
+import sys
+
+from credentialdigger import PgClient, SqliteClient
+
+logger = logging.getLogger(__name__)
+
+
+class customParser(argparse.ArgumentParser):
+    def error(self, message):
+        logger.error(f'{message}')
+        self.print_help()
+        exit()
+
+
+parser = customParser()
+
+parser.add_argument(
+    'path_to_rules',
+    type=str,
+    help='<Required> The path of the file that contains the rules.')
+
+parser.add_argument(
+    '--sqlite',
+    default=None,
+    type=str,
+    help='<Optional> If specified, scan the repo using the sqlite client \
+                     passing as argument the path of the db.\
+                     Otherwise, use postgres (must be up and running)')
+
+def add_rules(*pip_args):
+    """
+    Add rules to the database
+
+    Parameters
+    ----------
+    *pip_args
+        Keyword arguments for pip.
+
+    Raises
+    ------
+        FileNotFoundError
+            If the file does not exist
+        ParserError
+            If the file is malformed
+        KeyError
+            If one of the required attributes in the file (i.e., rules, regex,
+            and category) is missing
+    """
+
+    args = parser.parse_args(pip_args)
+
+    if args.sqlite:
+        c = SqliteClient(args.sqlite)
+        logger.info('Database in use: Sqlite')
+    else:
+        c = PgClient(dbname=os.getenv('POSTGRES_DB'),
+                     dbuser=os.getenv('POSTGRES_USER'),
+                     dbpassword=os.getenv('POSTGRES_PASSWORD'),
+                     dbhost=os.getenv('DBHOST'),
+                     dbport=int(os.getenv('DBPORT')))
+        logger.info('Database in use: Postgres')
+
+    c.add_rules_from_file(args.path_to_rules)
+
+    # This message will not be logged if the above operation fails,
+    # hence raising an exception.
+    logger.info('The rules have been added successfully.')

--- a/credentialdigger/add_rules.py
+++ b/credentialdigger/add_rules.py
@@ -1,7 +1,6 @@
 """
 The 'add_rules' modules add scanning rules from a file to the database.
 This module supports both Sqlite & Postegres databases.
-NOTE: Please make sure that the environment variables are exported.
 
 This command takes multiple arguments:
 path_to_rules       <Required> The path of the file that contains the rules.

--- a/credentialdigger/scan.py
+++ b/credentialdigger/scan.py
@@ -141,12 +141,14 @@ def scan(*pip_args):
 
     if args.sqlite:
         c = SqliteClient(args.sqlite)
+        logger.info('Database in use: Sqlite')
     else:
         c = PgClient(dbname=os.getenv('POSTGRES_DB'),
                      dbuser=os.getenv('POSTGRES_USER'),
                      dbpassword=os.getenv('POSTGRES_PASSWORD'),
                      dbhost=os.getenv('DBHOST'),
                      dbport=int(os.getenv('DBPORT')))
+        logger.info('Database in use: Postgres')
 
     discoveries = c.scan(
         repo_url=args.repo_url,


### PR DESCRIPTION
### Overview
This PR introduces a new CLI `add_rules` command. This command adds rules from a file to a database.

The goal of this PR is to help the user set up a running version of the `credentialdigger` in almost no time. In other words, the user will be able to get started with the tool after running 4 commands:

```bash
# Install the module
pip install credentialdigger
# Download the rules
wget https://raw.githubusercontent.com/SAP/credential-digger/develop/ui/backend/rules.yml -O rules.yml
# Add the rules to the database. This will also create the database in the process...
python -m credentialdigger add_rules rules.yml --sqlite cdigger.db
# Start a scan
python -m credentialdigger scan https://github.com/user/repo --sqlite cdigger.db
```
Without this command, the user will have to either use the UI to import the rules or write a python script that calls the `add_rules_from_file` function.

#### Background
I came up with this PR after seeing how you made the getting-started experience easier for users by loading the rules when the server starts: https://github.com/SAP/credential-digger/blob/85c43fbd3ed55a1edf7d0828ebcf02a5c49599f0/ui/server.py#L26

#### Another approach
We probably should consider inserting the rules whenever a new client (that does not contain the `rules` table) is constructed  using these SQL queries:
```sql

INSERT INTO "main"."rules"
  ("id", "regex", "category", "description")
VALUES
  ('1', '-----BEGIN [A-Z]+ PRIVATE KEY( BLOCK)?-----', 'crypto_key', 'private key');
INSERT INTO "main"."rules"
  ("id", "regex", "category", "description")
VALUES
  ('2', 'EAACEdEose0cBA[0-9A-Za-z]+', 'token', 'fb access token');
INSERT INTO "main"."rules"
  ("id", "regex", "category", "description")
VALUES
  ('3', '[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com', 'token', 'google token');
INSERT INTO "main"."rules"
  ("id", "regex", "category", "description")
VALUES
  ('4', 'AKIA[0-9A-Z]{16}', 'token', 'amazon token');
INSERT INTO "main"."rules"
  ("id", "regex", "category", "description")
VALUES
  ('5', '[0-9a-fA-F]{7}\.[0-9a-fA-F]{32}', 'token', 'instagram token');
INSERT INTO "main"."rules"
  ("id", "regex", "category", "description")
VALUES
  ('6', '[1-9][0-9]+-[0-9a-zA-Z]{40}', 'token', 'twitter access token');
INSERT INTO "main"."rules"
  ("id", "regex", "category", "description")
VALUES
  ('7', 'key-[0-9a-zA-Z]{32}', 'token', 'Mailgun API key');
INSERT INTO "main"."rules"
  ("id", "regex", "category", "description")
VALUES
  ('8', '[0-9a-f]{32}-us[0-9]{1,2}', 'token', 'MailChimp API key');
INSERT INTO "main"."rules"
  ("id", "regex", "category", "description")
VALUES
  ('9', 'sshpass|password|pwd|passwd|pass', 'password', 'password keywords');
```