### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Credential Digger is a GitHub scanning tool that identifies hardcoded credential
 
 -  [Requirements](#requirements)
 -  [Install](#install)
--  [Quick setup with UI](#quick-setup)
+-  [Quick launch with UI](#quick-launch)
 -  [Advanced Install](#advanced-install)
 	-  [Install from source](#install-from-source)
   	-  [Download machine learning models](#download-machine-learning-models)
@@ -23,9 +23,9 @@ Credential Digger is a GitHub scanning tool that identifies hardcoded credential
 
 ## Requirements
 
-Credential Digger supports Python 3.6, and works only with LINUX systems.
+Credential Digger supports Python >= 3.6 and < 3.8, and works only with LINUX systems.
 
-You need to have [Docker](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/)
+[Docker](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/) are needed if you want run an image of Credential Digger as a container, as discussed [here](#quick-launch).
 
 ## Install
 
@@ -41,7 +41,7 @@ _Please make sure to add the [scanning rules](https://github.com/SAP/credential-
 python -m credentialdigger scan https://github.com/user/repo --sqlite /path/to/data.db
 ```
 
-## Quick Setup
+## Quick Launch
 
 To have a ready-to-use instance of Credential Digger, with the UI:
 


### PR DESCRIPTION
- I believe that `launch` is a better word to use since we are not really setting the project up while running the docker image. We are `launching`/`running` it instead.

- It is not mandatory to have Docker & Docker-Compose to use the project. I agree, however, on the fact that it is a better-have asset if the user wants to work with the project in a separate container. (__i.e: the user can use the scanner via the CLI only, or as a python module__). 
Moreover, this will make the getting started experience easier for those who do not want to install extra software (Docker in this case...) to run the project.

PS: this is just my personal opinion.