### PR TITLE
add support for git token and api endpoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def requirements():
 
 setuptools.setup(
     name='credentialdigger',
-    version='2.0.2',
+    version='2.1.0',
     author='SAP SE',
     maintainer='Marco Rosa, Slim Trabelsi',
     maintainer_email='marco.rosa@sap.com, slim.trabelsi@sap.com',


### PR DESCRIPTION
Add an optional git_token parameter for the scans. Thanks to this, it is possible to scan private repositories on public servers (e.g., github.com private repos), and scan public/private repositories on servers where authentication is needed (e.g., private gitlab instances).

Moreover, support API endpoints other than `https://api.github.com` in `scan_user` function