### PR TITLE
Refactor and add scan commands to CLI

### DIFF
--- a/credentialdigger/cli/add_rules.py
+++ b/credentialdigger/cli/add_rules.py
@@ -38,16 +38,16 @@ def configure_parser(parser):
         help='The path of the file that contains the rules.')
 
 
-def run(args, client):
+def run(client, args):
     """
     Add rules to the database
 
     Parameters
     ----------
-    args: `argparse.Namespace`
-        Arguments from command line parser.
     client: `credentialdigger.Client`
         Instance of the client on which to save results
+    args: `argparse.Namespace`
+        Arguments from command line parser.
 
     Raises
     ------

--- a/credentialdigger/cli/add_rules.py
+++ b/credentialdigger/cli/add_rules.py
@@ -12,17 +12,12 @@ Usage:
 python -m credentialdigger add_rules /path/rules.yml
 
 """
-import argparse
 import logging
-import os
-import sys
-
-from credentialdigger import PgClient, SqliteClient
 
 logger = logging.getLogger(__name__)
 
 
-def add_rules(args):
+def add_rules(args, client):
     """
     Add rules to the database
 
@@ -30,6 +25,8 @@ def add_rules(args):
     ----------
     args: `argparse.Namespace`
         Arguments from command line parser.
+    client: `credentialdigger.Client`
+        Instance of the client on which to save results
 
     Raises
     ------
@@ -42,18 +39,7 @@ def add_rules(args):
             and category) is missing
     """
 
-    if args.sqlite:
-        c = SqliteClient(args.sqlite)
-        logger.info('Database in use: Sqlite')
-    else:
-        c = PgClient(dbname=os.getenv('POSTGRES_DB'),
-                     dbuser=os.getenv('POSTGRES_USER'),
-                     dbpassword=os.getenv('POSTGRES_PASSWORD'),
-                     dbhost=os.getenv('DBHOST'),
-                     dbport=os.getenv('DBPORT'))
-        logger.info('Database in use: Postgres')
-
-    c.add_rules_from_file(args.path_to_rules)
+    client.add_rules_from_file(args.path_to_rules)
 
     # This message will not be logged if the above operation fails,
     # hence raising an exception.

--- a/credentialdigger/cli/add_rules.py
+++ b/credentialdigger/cli/add_rules.py
@@ -2,14 +2,20 @@
 The 'add_rules' module adds scanning rules from a file to the database.
 This module supports both Sqlite & Postegres databases.
 
-This command takes multiple arguments:
-path_to_rules       <Required> The path of the file that contains the rules.
+usage: credentialdigger add_rules [-h] [--dotenv DOTENV] [--sqlite SQLITE]
+                                  path_to_rules
 
---sqlite DB_PATH    <Optional> If specified, use the sqlite client and
-                        the db passed as argument (otherwise use postgres)
+positional arguments:
+  path_to_rules    The path of the file that contains the rules.
 
-Usage:
-python -m credentialdigger add_rules /path/rules.yml
+optional arguments:
+  -h, --help       show this help message and exit
+  --dotenv DOTENV  The path to the .env file which will be used in all
+                   commands. If not specified, the one in the current
+                   directory will be used (if present).
+  --sqlite SQLITE  If specified, scan the repo using the sqlite client passing
+                   as argument the path of the db. Otherwise, use postgres
+                   (must be up and running)
 
 """
 import logging

--- a/credentialdigger/cli/add_rules.py
+++ b/credentialdigger/cli/add_rules.py
@@ -17,7 +17,22 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def add_rules(args, client):
+def configure_parser(parser):
+    """
+    Configure arguments for command line parser.
+
+    Parameters
+    ----------
+    parser: `credentialdigger.cli.customParser`
+        Command line parser
+    """
+    parser.set_defaults(func=run)
+    parser.add_argument(
+        'path_to_rules', type=str,
+        help='The path of the file that contains the rules.')
+
+
+def run(args, client):
     """
     Add rules to the database
 

--- a/credentialdigger/cli/cli.py
+++ b/credentialdigger/cli/cli.py
@@ -1,11 +1,10 @@
+import argparse
+import logging
 import os
 import sys
-import logging
-import argparse
-
-from dotenv import load_dotenv
 
 from credentialdigger import PgClient, SqliteClient
+from dotenv import load_dotenv
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +17,7 @@ class customParser(argparse.ArgumentParser):
 
 
 def main():
-    from . import scan, add_rules, download, scan_user, scan_wiki
+    from . import add_rules, download, scan, scan_user, scan_wiki
 
     # Main parser configuration
     main_parser = customParser('credentialdigger')
@@ -111,6 +110,6 @@ def main():
                               dbhost=os.getenv('DBHOST'),
                               dbport=os.getenv('DBPORT'))
             logger.info('Database in use: Postgres')
-        args.func(args, client)
+        args.func(client, args)
     else:
         args.func(args)

--- a/credentialdigger/cli/cli.py
+++ b/credentialdigger/cli/cli.py
@@ -18,7 +18,7 @@ class customParser(argparse.ArgumentParser):
 
 
 def main():
-    from . import scan, add_rules, download
+    from . import scan, add_rules, download, scan_user
 
     # Main parser configuration
     main_parser = customParser('credentialdigger')
@@ -56,6 +56,12 @@ def main():
         parents=[parser_dotenv, parser_sqlite])
     scan.configure_parser(parser_scan)
 
+    # scan_user subparser configuration
+    parser_scan_user = subparsers.add_parser(
+        'scan_user', help='Scan a GitHub user',
+        parents=[parser_dotenv, parser_sqlite])
+    scan_user.configure_parser(parser_scan_user)
+
     # Run the parser
     if len(sys.argv) == 1:
         main_parser.print_help()
@@ -65,7 +71,7 @@ def main():
     # If specified, load dotenv from the given path. Otherwise load from cwd
     load_dotenv(dotenv_path=args.dotenv, verbose=True)
 
-    if args.func in [scan.run, add_rules.run]:
+    if args.func in [scan.run, add_rules.run, scan_user.run]:
         # Connect to db only when running commands that need it
         if args.sqlite:
             client = SqliteClient(args.sqlite)

--- a/credentialdigger/cli/download.py
+++ b/credentialdigger/cli/download.py
@@ -10,6 +10,20 @@ independent from credentialdigger, that can be downloaded and installed a
 posteriori in order to provide additional features.
 
 In our use case these models are used to filter out false positive discoveries.
+
+usage: credentialdigger download [-h] [--dotenv DOTENV]
+                                 model [pip_args [pip_args ...]]
+
+positional arguments:
+  model            The name of the model. It must be an environment variable.
+  pip_args         Keyword arguments for pip.
+
+optional arguments:
+  -h, --help       show this help message and exit
+  --dotenv DOTENV  The path to the .env file which will be used in all
+                   commands. If not specified, the one in the current
+                   directory will be used (if present).
+
 """
 
 import importlib

--- a/credentialdigger/cli/download.py
+++ b/credentialdigger/cli/download.py
@@ -25,12 +25,30 @@ _data_path = Path(importlib.import_module(
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
+
+def configure_parser(parser):
+    """
+    Configure arguments for command line parser.
+
+    Parameters
+    ----------
+    parser: `credentialdigger.cli.customParser`
+        Command line parser
+    """
+    parser.set_defaults(func=run)
+    parser.add_argument(
+        'model', type=str,
+        help='The name of the model. It must be an environment variable.')
+    parser.add_argument(
+        'pip_args', nargs='*', default=None, help='Keyword arguments for pip.')
+
+
 # ############################################################################
 # Methods adapted from
 # https://github.com/explosion/spaCy/blob/master/spacy/cli/download.py
 
 
-def download(args):
+def run(args):
     """ Download a model and link it to the credental digger models_data
     folder.
 

--- a/credentialdigger/cli/scan.py
+++ b/credentialdigger/cli/scan.py
@@ -35,17 +35,14 @@ Usage:
 python -m credentialdigger scan REPO_URL --force --debug
 
 """
-import argparse
 import logging
-import os
 import sys
 
-from credentialdigger import PgClient, SqliteClient
 
 logger = logging.getLogger(__name__)
 
 
-def scan(args):
+def scan(args, client):
     """
     Scan a git repository.
 
@@ -53,6 +50,8 @@ def scan(args):
     ----------
     args: `argparse.Namespace`
         Arguments from command line parser.
+    client: `credentialdigger.Client`
+        Instance of the client on which to save results
 
     Returns
     -------
@@ -61,18 +60,8 @@ def scan(args):
         discoveries. If it exits with a value that is equal to 0, then it means
         that the scan detected no leaks in this repo.
     """
-    if args.sqlite:
-        c = SqliteClient(args.sqlite)
-        logger.info('Database in use: Sqlite')
-    else:
-        c = PgClient(dbname=os.getenv('POSTGRES_DB'),
-                     dbuser=os.getenv('POSTGRES_USER'),
-                     dbpassword=os.getenv('POSTGRES_PASSWORD'),
-                     dbhost=os.getenv('DBHOST'),
-                     dbport=os.getenv('DBPORT'))
-        logger.info('Database in use: Postgres')
 
-    discoveries = c.scan(
+    discoveries = client.scan(
         repo_url=args.repo_url,
         category=args.category,
         models=args.models,

--- a/credentialdigger/cli/scan.py
+++ b/credentialdigger/cli/scan.py
@@ -78,16 +78,16 @@ def configure_parser(parser):
             `False`, use the pre-trained extractor model')
 
 
-def run(args, client):
+def run(client, args):
     """
     Scan a git repository.
 
     Parameters
     ----------
-    args: `argparse.Namespace`
-        Arguments from command line parser.
     client: `credentialdigger.Client`
         Instance of the client on which to save results
+    args: `argparse.Namespace`
+        Arguments from command line parser.
 
     Returns
     -------

--- a/credentialdigger/cli/scan.py
+++ b/credentialdigger/cli/scan.py
@@ -38,11 +38,51 @@ python -m credentialdigger scan REPO_URL --force --debug
 import logging
 import sys
 
-
 logger = logging.getLogger(__name__)
 
 
-def scan(args, client):
+def configure_parser(parser):
+    """
+    Configure arguments for command line parser.
+
+    Parameters
+    ----------
+    parser: `credentialdigger.cli.customParser`
+        Command line parser
+    """
+    parser.set_defaults(func=run)
+    parser.add_argument(
+        'repo_url', type=str,
+        help='The URL of the git repository to be scanned.')
+    parser.add_argument(
+        '--category', default=None, type=str,
+        help=' If specified, scan the repo using all the rules of this \
+            category, otherwise use all the rules in the db')
+    parser.add_argument(
+        '--models', default=None, nargs='+',
+        help='A list of models for the ML false positives detection.\nCannot \
+            accept empty lists.')
+    parser.add_argument(
+        '--exclude', default=None, nargs='+',
+        help='A list of rules to exclude')
+    parser.add_argument(
+        '--force', action='store_true',
+        help='Force a complete re-scan of the repository, in case it has \
+            already been scanned previously')
+    parser.add_argument(
+        '--debug', action='store_true',
+        help='Flag used to decide whether to visualize the progressbars \
+            during the scan (e.g., during the insertion of the detections in \
+            the db)')
+    parser.add_argument(
+        '--generate_snippet_extractor',
+        action='store_true',
+        help='Generate the extractor model to be used in the SnippetModel. \
+            The extractor is generated using the ExtractorGenerator. If \
+            `False`, use the pre-trained extractor model')
+
+
+def run(args, client):
     """
     Scan a git repository.
 

--- a/credentialdigger/cli/scan_user.py
+++ b/credentialdigger/cli/scan_user.py
@@ -80,16 +80,16 @@ def configure_parser(parser):
         help='API endpoint of the git server')
 
 
-def run(args, client):
+def run(client, args):
     """
     Scan a GitHub user.
 
     Parameters
     ----------
-    args: `argparse.Namespace`
-        Arguments from command line parser.
     client: `credentialdigger.Client`
         Instance of the client on which to save results
+    args: `argparse.Namespace`
+        Arguments from command line parser.
     """
 
     discoveries = client.scan_user(

--- a/credentialdigger/cli/scan_user.py
+++ b/credentialdigger/cli/scan_user.py
@@ -1,0 +1,121 @@
+"""
+The 'scan_user' module can be used to scan a GitHub user on the fly from the
+terminal. It supports both the Sqlite and Postgres clients.
+
+NOTE: Postgres is used by default. Please make sure that the environment
+variables are exported and that the rules have already been added to the
+database.
+
+This command takes multiple arguments :
+  positional arguments:
+    username              The username as on github.com
+
+  optional arguments:
+    -h, --help            show this help message and exit
+    --dotenv DOTENV       The path to the .env file which will be used in all
+                          commands. If not specified, the one in the current
+                          directory will be used (if present).
+    --sqlite SQLITE       If specified, scan the repo using the sqlite client
+                          passing as argument the path of the db. Otherwise, use
+                          postgres (must be up and running)
+    --category CATEGORY   If specified, scan the repo using all the rules of
+                          this category, otherwise use all the rules in the db
+    --models MODELS [MODELS ...]
+                          A list of models for the ML false positives detection.
+                          Cannot accept empty lists.
+    --exclude EXCLUDE [EXCLUDE ...]
+                          A list of rules to exclude
+    --debug               Flag used to decide whether to visualize the
+                          progressbars during the scan (e.g., during the
+                          insertion of the detections in the db)
+    --generate_snippet_extractor
+                          Generate the extractor model to be used in the
+                          SnippetModel. The extractor is generated using the
+                          ExtractorGenerator. If `False`, use the pre-trained
+                          extractor model
+    --forks               Scan also repositories forked by this user
+    --git_token GIT_TOKEN
+                          Git personal access token to authenticate to the git
+                          server
+    --api_endpoint API_ENDPOINT
+                          API endpoint of the git server
+
+
+Usage:
+python -m credentialdigger scan_user USERNAME --debug
+
+"""
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def configure_parser(parser):
+    """
+    Configure arguments for command line parser.
+
+    Parameters
+    ----------
+    parser: `credentialdigger.cli.customParser`
+        Command line parser
+    """
+    parser.set_defaults(func=run)
+    parser.add_argument(
+        'username', type=str,
+        help='The username as on github.com')
+    parser.add_argument(
+        '--category', default=None, type=str,
+        help=' If specified, scan the repo using all the rules of this \
+            category, otherwise use all the rules in the db')
+    parser.add_argument(
+        '--models', default=None, nargs='+',
+        help='A list of models for the ML false positives detection.\nCannot \
+            accept empty lists.')
+    parser.add_argument(
+        '--exclude', default=None, nargs='+',
+        help='A list of rules to exclude')
+    parser.add_argument(
+        '--debug', action='store_true',
+        help='Flag used to decide whether to visualize the progressbars \
+            during the scan (e.g., during the insertion of the detections in \
+            the db)')
+    parser.add_argument(
+        '--generate_snippet_extractor', action='store_true',
+        help='Generate the extractor model to be used in the SnippetModel. \
+            The extractor is generated using the ExtractorGenerator. If \
+            `False`, use the pre-trained extractor model')
+    parser.add_argument(
+        '--forks', action='store_true', default=False,
+        help='Scan also repositories forked by this user')
+    parser.add_argument(
+        '--git_token', type=str, default=None,
+        help='Git personal access token to authenticate to the git server')
+    parser.add_argument(
+        '--api_endpoint', type=str, default='https://api.github.com',
+        help='API endpoint of the git server')
+
+
+def run(args, client):
+    """
+    Scan a GitHub user.
+
+    Parameters
+    ----------
+    args: `argparse.Namespace`
+        Arguments from command line parser.
+    client: `credentialdigger.Client`
+        Instance of the client on which to save results
+    """
+
+    discoveries = client.scan_user(
+        username=args.username,
+        category=args.category,
+        models=args.models,
+        exclude=args.exclude,
+        debug=args.debug,
+        generate_snippet_extractor=args.generate_snippet_extractor,
+        forks=args.forks,
+        git_token=args.git_token,
+        api_endpoint=args.api_endpoint)
+
+    logger.info("{} repositories scanned.".format(len(discoveries)))

--- a/credentialdigger/cli/scan_user.py
+++ b/credentialdigger/cli/scan_user.py
@@ -6,43 +6,47 @@ NOTE: Postgres is used by default. Please make sure that the environment
 variables are exported and that the rules have already been added to the
 database.
 
-This command takes multiple arguments :
-  positional arguments:
-    username              The username as on github.com
+usage: credentialdigger scan_user [-h] [--dotenv DOTENV] [--sqlite SQLITE]
+                                  [--category CATEGORY]
+                                  [--models MODELS [MODELS ...]]
+                                  [--exclude EXCLUDE [EXCLUDE ...]] [--debug]
+                                  [--git_token GIT_TOKEN]
+                                  [--generate_snippet_extractor] [--forks]
+                                  [--api_endpoint API_ENDPOINT]
+                                  username
 
-  optional arguments:
-    -h, --help            show this help message and exit
-    --dotenv DOTENV       The path to the .env file which will be used in all
-                          commands. If not specified, the one in the current
-                          directory will be used (if present).
-    --sqlite SQLITE       If specified, scan the repo using the sqlite client
-                          passing as argument the path of the db. Otherwise, use
-                          postgres (must be up and running)
-    --category CATEGORY   If specified, scan the repo using all the rules of
-                          this category, otherwise use all the rules in the db
-    --models MODELS [MODELS ...]
-                          A list of models for the ML false positives detection.
-                          Cannot accept empty lists.
-    --exclude EXCLUDE [EXCLUDE ...]
-                          A list of rules to exclude
-    --debug               Flag used to decide whether to visualize the
-                          progressbars during the scan (e.g., during the
-                          insertion of the detections in the db)
-    --generate_snippet_extractor
-                          Generate the extractor model to be used in the
-                          SnippetModel. The extractor is generated using the
-                          ExtractorGenerator. If `False`, use the pre-trained
-                          extractor model
-    --forks               Scan also repositories forked by this user
-    --git_token GIT_TOKEN
-                          Git personal access token to authenticate to the git
-                          server
-    --api_endpoint API_ENDPOINT
-                          API endpoint of the git server
+positional arguments:
+  username              The username as on github.com
 
-
-Usage:
-python -m credentialdigger scan_user USERNAME --debug
+optional arguments:
+  -h, --help            show this help message and exit
+  --dotenv DOTENV       The path to the .env file which will be used in all
+                        commands. If not specified, the one in the current
+                        directory will be used (if present).
+  --sqlite SQLITE       If specified, scan the repo using the sqlite client
+                        passing as argument the path of the db. Otherwise, use
+                        postgres (must be up and running)
+  --category CATEGORY   If specified, scan the repo using all the rules of
+                        this category, otherwise use all the rules in the db
+  --models MODELS [MODELS ...]
+                        A list of models for the ML false positives detection.
+                        Cannot accept empty lists.
+  --exclude EXCLUDE [EXCLUDE ...]
+                        A list of rules to exclude
+  --debug               Flag used to decide whether to visualize the
+                        progressbars during the scan (e.g., during the
+                        insertion of the detections in the db)
+  --git_token GIT_TOKEN
+                        Git personal access token to authenticate to the git
+                        server
+  --generate_snippet_extractor
+                        Generate the extractor model to be used in the
+                        SnippetModel. The extractor is generated using the
+                        ExtractorGenerator. If `False`, use the pre-trained
+                        extractor model
+  --forks               Scan also repositories forked by this user
+  --api_endpoint API_ENDPOINT
+                        API endpoint of the git server
 
 """
 import logging
@@ -64,22 +68,6 @@ def configure_parser(parser):
         'username', type=str,
         help='The username as on github.com')
     parser.add_argument(
-        '--category', default=None, type=str,
-        help=' If specified, scan the repo using all the rules of this \
-            category, otherwise use all the rules in the db')
-    parser.add_argument(
-        '--models', default=None, nargs='+',
-        help='A list of models for the ML false positives detection.\nCannot \
-            accept empty lists.')
-    parser.add_argument(
-        '--exclude', default=None, nargs='+',
-        help='A list of rules to exclude')
-    parser.add_argument(
-        '--debug', action='store_true',
-        help='Flag used to decide whether to visualize the progressbars \
-            during the scan (e.g., during the insertion of the detections in \
-            the db)')
-    parser.add_argument(
         '--generate_snippet_extractor', action='store_true',
         help='Generate the extractor model to be used in the SnippetModel. \
             The extractor is generated using the ExtractorGenerator. If \
@@ -87,9 +75,6 @@ def configure_parser(parser):
     parser.add_argument(
         '--forks', action='store_true', default=False,
         help='Scan also repositories forked by this user')
-    parser.add_argument(
-        '--git_token', type=str, default=None,
-        help='Git personal access token to authenticate to the git server')
     parser.add_argument(
         '--api_endpoint', type=str, default='https://api.github.com',
         help='API endpoint of the git server')
@@ -118,4 +103,4 @@ def run(args, client):
         git_token=args.git_token,
         api_endpoint=args.api_endpoint)
 
-    logger.info("{} repositories scanned.".format(len(discoveries)))
+    logger.info(f"{len(discoveries)} repositories scanned.")

--- a/credentialdigger/cli/scan_wiki.py
+++ b/credentialdigger/cli/scan_wiki.py
@@ -1,21 +1,20 @@
 """
-The 'scan' module can be used to scan a git repository on the fly from the
-terminal. It supports both the Sqlite and Postgres clients.
+The 'scan_wiki' module can be used to scan the wiki of a git repository on the 
+fly from the terminal. It supports both the Sqlite and Postgres clients.
 
 NOTE: Postgres is used by default. Please make sure that the environment
 variables are exported and that the rules have already been added to the
 database.
 
-usage: credentialdigger scan [-h] [--dotenv DOTENV] [--sqlite SQLITE]
-                             [--category CATEGORY]
-                             [--models MODELS [MODELS ...]]
-                             [--exclude EXCLUDE [EXCLUDE ...]] [--debug]
-                             [--git_token GIT_TOKEN] [--force]
-                             [--generate_snippet_extractor]
-                             repo_url
+usage: credentialdigger scan_wiki [-h] [--dotenv DOTENV] [--sqlite SQLITE]
+                                  [--category CATEGORY]
+                                  [--models MODELS [MODELS ...]]
+                                  [--exclude EXCLUDE [EXCLUDE ...]] [--debug]
+                                  [--git_token GIT_TOKEN]
+                                  repo_url
 
 positional arguments:
-  repo_url              The URL of the git repository to be scanned.
+  repo_url              The url of the repository
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -38,13 +37,6 @@ optional arguments:
   --git_token GIT_TOKEN
                         Git personal access token to authenticate to the git
                         server
-  --force               Force a complete re-scan of the repository, in case it
-                        has already been scanned previously
-  --generate_snippet_extractor
-                        Generate the extractor model to be used in the
-                        SnippetModel. The extractor is generated using the
-                        ExtractorGenerator. If `False`, use the pre-trained
-                        extractor model
 
 """
 import logging
@@ -65,17 +57,7 @@ def configure_parser(parser):
     parser.set_defaults(func=run)
     parser.add_argument(
         'repo_url', type=str,
-        help='The URL of the git repository to be scanned.')
-    parser.add_argument(
-        '--force', action='store_true',
-        help='Force a complete re-scan of the repository, in case it has \
-            already been scanned previously')
-    parser.add_argument(
-        '--generate_snippet_extractor',
-        action='store_true',
-        help='Generate the extractor model to be used in the SnippetModel. \
-            The extractor is generated using the ExtractorGenerator. If \
-            `False`, use the pre-trained extractor model')
+        help='The url of the repository')
 
 
 def run(args, client):
@@ -97,14 +79,12 @@ def run(args, client):
         that the scan detected no leaks in this repo.
     """
 
-    discoveries = client.scan(
+    discoveries = client.scan_wiki(
         repo_url=args.repo_url,
         category=args.category,
         models=args.models,
         exclude=args.exclude,
-        force=args.force,
         debug=args.debug,
-        generate_snippet_extractor=args.generate_snippet_extractor,
         git_token=args.git_token)
 
     sys.exit(len(discoveries))

--- a/credentialdigger/cli/scan_wiki.py
+++ b/credentialdigger/cli/scan_wiki.py
@@ -60,16 +60,16 @@ def configure_parser(parser):
         help='The url of the repository')
 
 
-def run(args, client):
+def run(client, args):
     """
     Scan a git repository.
 
     Parameters
     ----------
-    args: `argparse.Namespace`
-        Arguments from command line parser.
     client: `credentialdigger.Client`
         Instance of the client on which to save results
+    args: `argparse.Namespace`
+        Arguments from command line parser.
 
     Returns
     -------

--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -762,7 +762,7 @@ class Client(Interface):
                   models=None, exclude=None, debug=False, git_token=None):
         """ Scan the wiki of a repository.
 
-        This method simply generate the url of a wiki from the url of its repo,
+        This method simply generates the url of a wiki from the url of its repo,
         and uses the same `scan` method that we use for repositories.
 
         Parameters


### PR DESCRIPTION
This PR brings two existing scan commands to the CLI: `scan_user` and `scan_wiki`. They both use their respective underlying method in the `client`.
Since many CLI arguments are the same across all scan types, I centralized all common arguments in the `parser_scan_base` parser, in order to be DRY.

Furthermore, since adding more commands was cluttering the `cli.py` file, I splitted the command-specific parser configurations in the relative files, structuring them with `configure_parser` and `run` methods, so that they can be called from the main cli file.