### PR TITLE
Split lines based on python's splitlines method

### DIFF
--- a/credentialdigger/scanners/git_scanner.py
+++ b/credentialdigger/scanners/git_scanner.py
@@ -210,7 +210,7 @@ class GitScanner(BaseScanner):
         detections = []
         r_hunkheader = re.compile(r"@@\s*\-\d+(\,\d+)?\s\+(\d+)((\,\d+)?).*@@")
         r_hunkaddition = re.compile(r"^\+\s*(\S(.*\S)?)\s*$")
-        rows = printable_diff.split('\n')
+        rows = printable_diff.splitlines()
         line_number = 1
         for row in rows:
             if row.startswith('-') or len(row) > 500:


### PR DESCRIPTION
This PR solves a bug where commits containing CRLF newlines would result in discoveries containing a trailing `\r`. 
This currently creates problems in querying discoveries from the UI.

The PR handles newlines split through python's `splitlines()` integrated method, which takes care of LF, CRLF, and a bunch of other newline separators.