### PR TITLE
Use last scan timestamp instead of last commit as a starting point for the scan

### DIFF
--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -423,7 +423,7 @@ class Client(Interface):
         ----------
         url: str
             The url of the repository scanned
-        last_scan: str
+        last_scan: int
             The timestamp of the last scan
 
         Returns
@@ -492,7 +492,6 @@ class Client(Interface):
         repo_url: str
             The url of the repo to scan
         category: str, optional
-            self.db.commit()
             If specified, scan the repo using all the rules of this category,
             otherwise use all the rules in the db
         scanner: class, default: `GitScanner`

--- a/credentialdigger/client_postgres.py
+++ b/credentialdigger/client_postgres.py
@@ -302,18 +302,18 @@ class PgClient(Client):
             query='SELECT file_name, snippet, count(id), state FROM \
             discoveries WHERE repo_url=%s GROUP BY file_name, snippet, state')
 
-    def update_repo(self, url, last_commit):
-        """ Update the last commit of a repo.
+    def update_repo(self, url, last_scan):
+        """ Update the last scan timestamp of a repo.
 
-        After a scan, record what is the most recent commit scanned, such that
+        After a scan, record the timestamp of the last scan, such that
         another (future) scan will not process the same commits twice.
 
         Parameters
         ----------
         url: str
             The url of the repository scanned
-        last_commit: str
-            The most recent commit scanned
+        last_scan: str
+            The timestamp of the last scan
 
         Returns
         -------
@@ -321,9 +321,8 @@ class PgClient(Client):
             `True` if the update is successful, `False` otherwise
         """
         super().update_repo(
-            url=url,
-            last_commit=last_commit,
-            query='UPDATE repos SET last_commit=%s WHERE url=%s RETURNING true'
+            url=url, last_scan=last_scan,
+            query='UPDATE repos SET last_scan=%s WHERE url=%s RETURNING true'
         )
 
     def update_discovery(self, discovery_id, new_state):

--- a/credentialdigger/client_postgres.py
+++ b/credentialdigger/client_postgres.py
@@ -312,7 +312,7 @@ class PgClient(Client):
         ----------
         url: str
             The url of the repository scanned
-        last_scan: str
+        last_scan: int
             The timestamp of the last scan
 
         Returns

--- a/credentialdigger/client_sqlite.py
+++ b/credentialdigger/client_sqlite.py
@@ -22,7 +22,7 @@ class SqliteClient(Client):
         cursor.executescript("""
             CREATE TABLE IF NOT EXISTS repos(
                 url TEXT NOT NULL UNIQUE,
-                last_commit TEXT,
+                last_scan INTEGER,
                 PRIMARY KEY (url)
             );
 
@@ -317,18 +317,18 @@ class SqliteClient(Client):
                 WHERE repo_url=? GROUP BY file_name, snippet, state'
                                            )
 
-    def update_repo(self, url, last_commit):
-        """ Update the last commit of a repo.
+    def update_repo(self, url, last_scan):
+        """ Update the last scan timestamp of a repo.
 
-        After a scan, record what is the most recent commit scanned, such that
+        After a scan, record the timestamp of the last scan, such that
         another (future) scan will not process the same commits twice.
 
         Parameters
         ----------
         url: str
             The url of the repository scanned
-        last_commit: str
-            The most recent commit scanned
+        last_scan: str
+            The timestamp of the last scan
 
         Returns
         -------
@@ -336,8 +336,8 @@ class SqliteClient(Client):
             `True` if the update is successful, `False` otherwise
         """
         super().update_repo(
-            url=url, last_commit=last_commit,
-            query='UPDATE repos SET last_commit=? WHERE url=?'
+            url=url, last_scan=last_scan,
+            query='UPDATE repos SET last_scan=? WHERE url=?'
         )
 
     def update_discovery(self, discovery_id, new_state):

--- a/credentialdigger/client_sqlite.py
+++ b/credentialdigger/client_sqlite.py
@@ -327,7 +327,7 @@ class SqliteClient(Client):
         ----------
         url: str
             The url of the repository scanned
-        last_scan: str
+        last_scan: int
             The timestamp of the last scan
 
         Returns

--- a/credentialdigger/scanners/git_scanner.py
+++ b/credentialdigger/scanners/git_scanner.py
@@ -1,11 +1,11 @@
 import hashlib
-import shutil
 import re
+import shutil
 from datetime import datetime, timezone
 
 import hyperscan
-from git import Repo as GitRepo
 from git import NULL_TREE
+from git import Repo as GitRepo
 
 from .base_scanner import BaseScanner
 
@@ -72,9 +72,7 @@ class GitScanner(BaseScanner):
         project_path = self.clone_git_repo(git_url)
         repo = GitRepo(project_path)
 
-        try:
-            repo.rev_parse('HEAD').hexsha
-        except BadName:
+        if len(repo.branches) == 0:
             # The repository is empty
             return None, []
 

--- a/credentialdigger/scanners/git_scanner.py
+++ b/credentialdigger/scanners/git_scanner.py
@@ -63,8 +63,8 @@ class GitScanner(BaseScanner):
 
         Returns
         -------
-        str
-            The latest commit (`None` if the repository is empty)
+        int
+            The latest scan timestamp (now) (`None` if the repository is empty)
         list
             A list of discoveries (dictionaries). If there are no discoveries
             return an empty list
@@ -90,16 +90,15 @@ class GitScanner(BaseScanner):
             # prev_commit is newer than curr_commit
             for curr_commit in repo.iter_commits(branch_name,
                                                  max_count=max_depth):
-                if curr_commit.committed_date < since_timestamp:
-                    # We have reached the (chosen) oldest commit, so continue
-                    # with another branch
+                if curr_commit.committed_date <= since_timestamp:
+                    # We have reached the (chosen) oldest timestamp, so
+                    # continue with another branch
                     break
 
                 # if not prev_commit, then curr_commit is the newest commit
                 # (and we have nothing to diff with).
                 # But we will diff the first commit with NULL_TREE here to
-                # check the oldest code.
-                # In this way, no commit will be missed.
+                # check the oldest code. In this way, no commit will be missed.
                 # This is useful for git merge: in case of a merge, we have the
                 # same commits (prev and current) in two different branches.
                 # This trick avoids scanning twice the same commits
@@ -129,10 +128,11 @@ class GitScanner(BaseScanner):
                                                               prev_commit)
                 prev_commit = curr_commit
 
-            # Handling the first commit (either from since_timestamp or the oldest)
+            # Handling the first commit (either from since_timestamp or the
+            # oldest).
             # If `since_timestamp` is set, then there is no need to scan it
             # (because we have already scanned this diff at the previous step).
-            # If `since_timestamp` is None, we have reached the first commit of
+            # If `since_timestamp` is 0, we have reached the first commit of
             # the repo, and the diff here must be calculated with an empty tree
             if since_timestamp == 0:
                 diff = curr_commit.diff(NULL_TREE,

--- a/sql/create_table.sql
+++ b/sql/create_table.sql
@@ -2,7 +2,7 @@ CREATE TYPE STATES AS ENUM ('new', 'false_positive', 'addressing', 'not_relevant
 
 CREATE TABLE repos (
   url TEXT NOT NULL UNIQUE,
-  last_commit TEXT,
+  last_scan INTEGER,
   PRIMARY KEY (url)
 );
 

--- a/ui/server.py
+++ b/ui/server.py
@@ -21,7 +21,7 @@ app = Flask('__name__', static_folder=os.path.join(APP_ROOT, './res'),
 app.config['UPLOAD_FOLDER'] = os.path.join(APP_ROOT, './backend')
 app.config['DEBUG'] = True  # Remove this line in production
 
-if os.getenv('USE_PG'):
+if os.getenv('USE_PG') is True:
     app.logger.info('Use Postgres Client')
     c = PgClient(dbname=os.getenv('POSTGRES_DB'),
                  dbuser=os.getenv('POSTGRES_USER'),


### PR DESCRIPTION
This PR deprecates the use of the last commit to start the scan and proposes the use of the timestamp of the last scan instead.
The inner workings of the `git_scanner` and `client` remain the same.
Note: to do this, the column `last_commit` in the repos table of the database gets renamed in `last_scan`. 