### PR TITLE
Add UI clients

### DIFF
--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -334,7 +334,7 @@ class Client(Interface):
         repo_url: str
             The url of the repository
         file_name: str, optional
-            The filename to filter discoveries on
+            The name of the file to filter discoveries on
 
         Returns
         -------

--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -18,9 +18,6 @@ Repo = namedtuple('Repo', 'url last_scan')
 Discovery = namedtuple(
     'Discovery',
     'id file_name commit_id line_number snippet repo_url rule_id state timestamp')
-FilesSummary = namedtuple(
-    'FilesSummary',
-    'file_name tot_discoveries new false_positives addressing not_relevant')
 
 
 class Interface(ABC):
@@ -359,33 +356,6 @@ class Client(Interface):
             all_discoveries.append(dict(Discovery(*result)._asdict()))
             result = cursor.fetchone()
         return all_discoveries
-
-    def get_files_summary(self, query, repo_url):
-        """ Get aggregated discoveries info on all files of a repository.
-
-        Parameters
-        ----------
-        repo_url: str
-            The url of the repository
-
-        Returns
-        -------
-        list
-            A list of files with aggregated data (dictionaries)
-
-        Raises
-        ------
-            TypeError
-                If any of the required arguments is missing
-        """
-        cursor = self.db.cursor()
-        files = []
-        cursor.execute(query, (repo_url,))
-        result = cursor.fetchone()
-        while result:
-            files.append(dict(FilesSummary(*result)._asdict()))
-            result = cursor.fetchone()
-        return files
 
     def get_discovery(self, query, discovery_id):
         """ Get a discovery.

--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -336,6 +336,8 @@ class Client(Interface):
         ----------
         repo_url: str
             The url of the repository
+        file_name: str, optional
+            The filename to filter discoveries on
 
         Returns
         -------

--- a/credentialdigger/client_postgres.py
+++ b/credentialdigger/client_postgres.py
@@ -264,32 +264,6 @@ class PgClient(Client):
             file_name=file_name,
             query=query)
 
-    def get_files_summary(self, repo_url):
-        """ Get aggregated discoveries info on all files of a repository.
-
-        Parameters
-        ----------
-        repo_url: str
-            The url of the repository
-
-        Returns
-        -------
-        list
-            A list of files with aggregated data (dictionaries)
-        """
-        return super().get_files_summary(
-            repo_url=repo_url,
-            query=(
-                "SELECT file_name,"
-                " COUNT(*) AS tot_discoveries,"
-                " COUNT(CASE WHEN state='new' THEN 1 END) AS new,"
-                " COUNT(CASE WHEN state='false_positive' THEN 1 END) AS false_positives,"
-                " COUNT(CASE WHEN state='addressing' THEN 1 END) AS addressing,"
-                " COUNT(CASE WHEN state='not_relevant' THEN 1 END) AS not_relevant"
-                " FROM discoveries WHERE repo_url=%s"
-                " GROUP BY file_name"
-            ))
-
     def get_discovery(self, discovery_id):
         """ Get a discovery.
 

--- a/credentialdigger/client_postgres.py
+++ b/credentialdigger/client_postgres.py
@@ -248,6 +248,8 @@ class PgClient(Client):
         ----------
         repo_url: str
             The url of the repository
+        file_name: str, optional
+            The filename to filter discoveries on
 
         Returns
         -------

--- a/credentialdigger/client_sqlite.py
+++ b/credentialdigger/client_sqlite.py
@@ -280,32 +280,6 @@ class SqliteClient(Client):
             file_name=file_name,
             query=query)
 
-    def get_files_summary(self, repo_url):
-        """ Get aggregated discoveries info on all files of a repository.
-
-        Parameters
-        ----------
-        repo_url: str
-            The url of the repository
-
-        Returns
-        -------
-        list
-            A list of files with aggregated data (dictionaries)
-        """
-        return super().get_files_summary(
-            repo_url=repo_url,
-            query=(
-                "SELECT file_name,"
-                " COUNT(*) AS tot_discoveries,"
-                " COUNT(CASE WHEN state='new' THEN 1 END) AS new,"
-                " COUNT(CASE WHEN state='false_positive' THEN 1 END) AS false_positives,"
-                " COUNT(CASE WHEN state='addressing' THEN 1 END) AS addressing,"
-                " COUNT(CASE WHEN state='not_relevant' THEN 1 END) AS not_relevant"
-                " FROM discoveries WHERE repo_url=?"
-                " GROUP BY file_name"
-            ))
-
     def get_discovery(self, discovery_id):
         """ Get a discovery.
 

--- a/credentialdigger/client_sqlite.py
+++ b/credentialdigger/client_sqlite.py
@@ -15,6 +15,7 @@ class SqliteClient(Client):
         path: str
             Database file (':memory:' is in RAM memory)
         """
+        print('enter sqlite init')
         super().__init__(connect(database=path, check_same_thread=False),
                          Error)
         # Create database if not exist
@@ -263,6 +264,8 @@ class SqliteClient(Client):
         ----------
         repo_url: str
             The url of the repository
+        file_name: str, optional
+            The filename to filter discoveries on
 
         Returns
         -------

--- a/credentialdigger/client_sqlite.py
+++ b/credentialdigger/client_sqlite.py
@@ -15,7 +15,6 @@ class SqliteClient(Client):
         path: str
             Database file (':memory:' is in RAM memory)
         """
-        print('enter sqlite init')
         super().__init__(connect(database=path, check_same_thread=False),
                          Error)
         # Create database if not exist

--- a/ui/backend/__init__.py
+++ b/ui/backend/__init__.py
@@ -1,0 +1,3 @@
+from .client_ui import UiClient
+from .client_ui_postgres import PgUiClient
+from .client_ui_sqlite import SqliteUiClient

--- a/ui/backend/client_ui.py
+++ b/ui/backend/client_ui.py
@@ -1,0 +1,30 @@
+from credentialdigger import Client
+from credentialdigger.client import Discovery
+
+
+class UiClient(Client):
+    def get_discoveries(self, query, params):
+        """ Get all the discoveries of a repository.
+
+        Parameters
+        ----------
+        TODO: docs
+
+        Returns
+        -------
+        list
+            A list of discoveries (dictionaries)
+
+        Raises
+        ------
+            TypeError
+                If any of the required arguments is missing
+        """
+        all_discoveries = []
+        cursor = self.db.cursor()
+        cursor.execute(query, tuple(params))
+        result = cursor.fetchone()
+        while result:
+            all_discoveries.append(dict(Discovery(*result)._asdict()))
+            result = cursor.fetchone()
+        return all_discoveries

--- a/ui/backend/client_ui.py
+++ b/ui/backend/client_ui.py
@@ -1,5 +1,11 @@
+from collections import namedtuple
+
 from credentialdigger import Client
 from credentialdigger.client import Discovery
+
+FilesSummary = namedtuple(
+    'FilesSummary',
+    'file_name tot_discoveries new false_positives addressing not_relevant')
 
 
 class UiClient(Client):
@@ -28,3 +34,30 @@ class UiClient(Client):
             all_discoveries.append(dict(Discovery(*result)._asdict()))
             result = cursor.fetchone()
         return all_discoveries
+
+    def get_files_summary(self, query, repo_url):
+        """ Get aggregated discoveries info on all files of a repository.
+
+        Parameters
+        ----------
+        repo_url: str
+            The url of the repository
+
+        Returns
+        -------
+        list
+            A list of files with aggregated data (dictionaries)
+
+        Raises
+        ------
+            TypeError
+                If any of the required arguments is missing
+        """
+        cursor = self.db.cursor()
+        files = []
+        cursor.execute(query, (repo_url,))
+        result = cursor.fetchone()
+        while result:
+            files.append(dict(FilesSummary(*result)._asdict()))
+            result = cursor.fetchone()
+        return files

--- a/ui/backend/client_ui.py
+++ b/ui/backend/client_ui.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 
 from credentialdigger import Client
-from credentialdigger.client import Discovery
 
 FilesSummary = namedtuple(
     'FilesSummary',
@@ -10,6 +9,9 @@ FilesSummary = namedtuple(
 
 class UiClient(Client):
     def get_discoveries(self, query, params):
+        pass
+
+    def get_discoveries_count(self, query, params):
         """ Get all the discoveries of a repository.
 
         Parameters
@@ -26,14 +28,10 @@ class UiClient(Client):
             TypeError
                 If any of the required arguments is missing
         """
-        all_discoveries = []
         cursor = self.db.cursor()
         cursor.execute(query, tuple(params))
-        result = cursor.fetchone()
-        while result:
-            all_discoveries.append(dict(Discovery(*result)._asdict()))
-            result = cursor.fetchone()
-        return all_discoveries
+        result = cursor.fetchone()[0]
+        return result
 
     def get_files_summary(self, query, repo_url):
         """ Get aggregated discoveries info on all files of a repository.

--- a/ui/backend/client_ui.py
+++ b/ui/backend/client_ui.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from collections import namedtuple
 
 from credentialdigger import Client
@@ -8,26 +9,12 @@ FilesSummary = namedtuple(
 
 
 class UiClient(Client):
+    @abstractmethod
     def get_discoveries(self, query, params):
         pass
 
     def get_discoveries_count(self, query, params):
-        """ Get all the discoveries of a repository.
 
-        Parameters
-        ----------
-        TODO: docs
-
-        Returns
-        -------
-        list
-            A list of discoveries (dictionaries)
-
-        Raises
-        ------
-            TypeError
-                If any of the required arguments is missing
-        """
         cursor = self.db.cursor()
         cursor.execute(query, tuple(params))
         result = cursor.fetchone()[0]

--- a/ui/backend/client_ui_postgres.py
+++ b/ui/backend/client_ui_postgres.py
@@ -32,18 +32,30 @@ class PgUiClient(UiClient, PgClient):
         if file_name is not None:
             query += ' AND file_name=%s'
             params.append(file_name)
+        query += (' AND snippet IN (SELECT snippet FROM ('
+                  'SELECT DISTINCT snippet, state, rule_id FROM discoveries WHERE repo_url=%s')
+        params.append(repo_url)
+        if file_name is not None:
+            query += ' AND file_name=%s'
+            params.append(file_name)
         if where is not None:
             query += ' AND snippet LIKE %%%s%%'
             params.append(where)
+        if order_by in ['category', 'snippet', 'state']:
+            if order_by == 'category':
+                order_by = 'rule_id'
+                # FIX: refactor this
+            query += f' ORDER BY {order_by}'
+            # params.append(order_direction)
+            # TODO: order by ENUM does not accept ASC|DESC but needs an integer
         if limit is not None:
             query += ' LIMIT %s'
             params.append(limit)
         if offset is not None:
             query += ' OFFSET %s'
             params.append(offset)
-        if order_by is not None:
-            query += 'ORDER BY %s %s'
-            params.append(order_by, order_direction)
+
+        query += ') as temp)'
 
         return super().get_discoveries(query, params)
 
@@ -72,3 +84,47 @@ class PgUiClient(UiClient, PgClient):
                 " FROM discoveries WHERE repo_url=%s"
                 " GROUP BY file_name"
             ))
+
+    # def get_files_summary(self, repo_url, where=None, limit=None, offset=None,
+    #                       order_by=None, order_direction='ASC'):
+    #     """ Get aggregated discoveries info on all files of a repository.
+
+    #     Parameters
+    #     ----------
+    #     repo_url: str
+    #         The url of the repository
+
+    #     Returns
+    #     -------
+    #     list
+    #         A list of files with aggregated data (dictionaries)
+    #     """
+    #     query = (
+    #         "SELECT file_name,"
+    #         " COUNT(*) AS tot_discoveries,"
+    #         " COUNT(CASE WHEN state='new' THEN 1 END) AS new,"
+    #         " COUNT(CASE WHEN state='false_positive' THEN 1 END) AS false_positives,"
+    #         " COUNT(CASE WHEN state='addressing' THEN 1 END) AS addressing,"
+    #         " COUNT(CASE WHEN state='not_relevant' THEN 1 END) AS not_relevant"
+    #         " FROM discoveries WHERE repo_url=%s"
+    #     )
+
+    #     params = [repo_url]
+
+    #     if where is not None:
+    #         query += ' AND file_name LIKE %%%s%%'
+    #         params.append(where)
+    #     if limit is not None:
+    #         query += ' LIMIT %s'
+    #         params.append(limit)
+    #     if offset is not None:
+    #         query += ' OFFSET %s'
+    #         params.append(offset)
+    #     if order_by is not None:
+    #         query += 'ORDER BY %s %s'
+    #         params.append(order_by, order_direction)
+
+    #     query += " GROUP BY file_name"
+    #     return super().get_files_summary(
+    #         repo_url=repo_url,
+    #         query=query)

--- a/ui/backend/client_ui_postgres.py
+++ b/ui/backend/client_ui_postgres.py
@@ -8,24 +8,35 @@ class PgUiClient(UiClient, PgClient):
     def get_discoveries(self, repo_url, file_name=None, where=None, limit=None,
                         offset=None, order_by=None, order_direction='ASC'):
         """ Get all the discoveries of a repository.
+        Supports full pagination by passing the respective parameters.
 
         Parameters
         ----------
         repo_url: str
             The url of the repository
         file_name: str, optional
-            The filename to filter discoveries on
-        TODO: docs
+            The name of the file to filter discoveries on
+        where: str, optional
+            Part of text contained in the snippet to filter discoveries on
+            (using SQL LIKE clause)
+        limit: int, optional
+            Number of unique discoveries to return. All occurrences of the
+            unique discoveries will be returned. (A unique discovery
+            corresponds to a distinct (snippet, state, rule_id) value)
+        offset: int, optional
+            Number of unique discoveries to start pagination from
+        order_by: str, optional
+            Name of the property on which to order results
+            (properties currently supported: category, snippet, state)
+        order_direction: str, optional
+            Direction of the sorting (either 'asc' or 'desc')
 
         Returns
         -------
+        int
+            The total number of discoveries (non-paginated)
         list
             A list of discoveries (dictionaries)
-
-        Raises
-        ------
-            TypeError
-                If any of the required arguments is missing
         """
         # Build inner query to get paginated unique snippets
         inner_params = [repo_url]
@@ -80,25 +91,23 @@ class PgUiClient(UiClient, PgClient):
         return total_discoveries, all_discoveries
 
     def get_discoveries_count(self, repo_url=None, file_name=None, where=None):
-        """ Get all the discoveries of a repository.
+        """ Get the toal number of discoveries.
 
         Parameters
         ----------
-        repo_url: str
-            The url of the repository
+        repo_url: str, optional
+            The url of the repository. (returns the total number of discoveries
+            in the database if not provided)
         file_name: str, optional
-            The filename to filter discoveries on
-        TODO: docs
+            The name of the file to filter discoveries on
+        where: str, optional
+            Part of text contained in the snippet to filter discoveries on
+            (using SQL LIKE clause)
 
         Returns
         -------
-        list
-            A list of discoveries (dictionaries)
-
-        Raises
-        ------
-            TypeError
-                If any of the required arguments is missing
+        int
+            The total number of discoveries
         """
         query = 'SELECT COUNT(*) FROM discoveries'
         params = []

--- a/ui/backend/client_ui_postgres.py
+++ b/ui/backend/client_ui_postgres.py
@@ -1,0 +1,48 @@
+from credentialdigger import Client, PgClient
+from psycopg2 import Error, connect
+
+from .client_ui import UiClient
+
+
+class PgUiClient(UiClient, PgClient):
+    def get_discoveries(self, repo_url, file_name=None, where=None, limit=None,
+                        offset=None, order_by=None, order_direction='ASC'):
+        """ Get all the discoveries of a repository.
+
+        Parameters
+        ----------
+        repo_url: str
+            The url of the repository
+        file_name: str, optional
+            The filename to filter discoveries on
+        TODO: docs
+
+        Returns
+        -------
+        list
+            A list of discoveries (dictionaries)
+
+        Raises
+        ------
+            TypeError
+                If any of the required arguments is missing
+        """
+        query = 'SELECT * FROM discoveries WHERE repo_url=%s'
+        params = [repo_url]
+        if file_name is not None:
+            query += ' AND file_name=%s'
+            params.append(file_name)
+        if where is not None:
+            query += ' AND snippet LIKE %%%s%%'
+            params.append(where)
+        if limit is not None:
+            query += ' LIMIT %s'
+            params.append(limit)
+        if offset is not None:
+            query += ' OFFSET %s'
+            params.append(offset)
+        if order_by is not None:
+            query += 'ORDER BY %s %s'
+            params.append(order_by, order_direction)
+
+        return super().get_discoveries(query, params)

--- a/ui/backend/client_ui_postgres.py
+++ b/ui/backend/client_ui_postgres.py
@@ -46,3 +46,29 @@ class PgUiClient(UiClient, PgClient):
             params.append(order_by, order_direction)
 
         return super().get_discoveries(query, params)
+
+    def get_files_summary(self, repo_url):
+        """ Get aggregated discoveries info on all files of a repository.
+
+        Parameters
+        ----------
+        repo_url: str
+            The url of the repository
+
+        Returns
+        -------
+        list
+            A list of files with aggregated data (dictionaries)
+        """
+        return super().get_files_summary(
+            repo_url=repo_url,
+            query=(
+                "SELECT file_name,"
+                " COUNT(*) AS tot_discoveries,"
+                " COUNT(CASE WHEN state='new' THEN 1 END) AS new,"
+                " COUNT(CASE WHEN state='false_positive' THEN 1 END) AS false_positives,"
+                " COUNT(CASE WHEN state='addressing' THEN 1 END) AS addressing,"
+                " COUNT(CASE WHEN state='not_relevant' THEN 1 END) AS not_relevant"
+                " FROM discoveries WHERE repo_url=%s"
+                " GROUP BY file_name"
+            ))

--- a/ui/backend/client_ui_sqlite.py
+++ b/ui/backend/client_ui_sqlite.py
@@ -1,0 +1,48 @@
+from credentialdigger import Client, SqliteClient
+from psycopg2 import Error, connect
+
+from .client_ui import UiClient
+
+
+class SqliteUiClient(UiClient, SqliteClient):
+    def get_discoveries(self, repo_url, file_name=None, where=None, limit=None,
+                        offset=None, order_by=None, order_direction='ASC'):
+        """ Get all the discoveries of a repository.
+
+        Parameters
+        ----------
+        repo_url: str
+            The url of the repository
+        file_name: str, optional
+            The filename to filter discoveries on
+        TODO: docs
+
+        Returns
+        -------
+        list
+            A list of discoveries (dictionaries)
+
+        Raises
+        ------
+            TypeError
+                If any of the required arguments is missing
+        """
+        query = 'SELECT * FROM discoveries WHERE repo_url=?'
+        params = [repo_url]
+        if file_name is not None:
+            query += ' AND file_name=?'
+            params.append(file_name)
+        if where is not None:
+            query += ' AND snippet LIKE %%?%%'
+            params.append(where)
+        if limit is not None:
+            query += ' LIMIT ?'
+            params.append(limit)
+        if offset is not None:
+            query += ' OFFSET ?'
+            params.append(offset)
+        if order_by is not None:
+            query += 'ORDER BY ? ?'
+            params.append(order_by, order_direction)
+
+        return super().get_discoveries(query, params)

--- a/ui/backend/client_ui_sqlite.py
+++ b/ui/backend/client_ui_sqlite.py
@@ -79,7 +79,8 @@ class SqliteUiClient(UiClient, SqliteClient):
         if file_name is not None:
             query += ' AND file_name=?'
             params.append(file_name)
-        query += f' AND (snippet, state) IN (VALUES {", ".join(["(?,?)"]*n_snippets)})'
+        query += (f' AND(snippet, state) IN('
+                  f'VALUES {", ".join(["(?, ?)"]*n_snippets)})')
         params.extend(snippets)
 
         # Execute outer query

--- a/ui/backend/client_ui_sqlite.py
+++ b/ui/backend/client_ui_sqlite.py
@@ -8,24 +8,35 @@ class SqliteUiClient(UiClient, SqliteClient):
     def get_discoveries(self, repo_url, file_name=None, where=None, limit=None,
                         offset=None, order_by=None, order_direction='ASC'):
         """ Get all the discoveries of a repository.
+        Supports full pagination by passing the respective parameters.
 
         Parameters
         ----------
         repo_url: str
             The url of the repository
         file_name: str, optional
-            The filename to filter discoveries on
-        TODO: docs
+            The name of the file to filter discoveries on
+        where: str, optional
+            Part of text contained in the snippet to filter discoveries on
+            (using SQL LIKE clause)
+        limit: int, optional
+            Number of unique discoveries to return. All occurrences of the
+            unique discoveries will be returned. (A unique discovery
+            corresponds to a distinct (snippet, state, rule_id) value)
+        offset: int, optional
+            Number of unique discoveries to start pagination from
+        order_by: str, optional
+            Name of the property on which to order results
+            (properties currently supported: category, snippet, state)
+        order_direction: str, optional
+            Direction of the sorting (either 'asc' or 'desc')
 
         Returns
         -------
+        int
+            The total number of discoveries (non-paginated)
         list
             A list of discoveries (dictionaries)
-
-        Raises
-        ------
-            TypeError
-                If any of the required arguments is missing
         """
         # Build inner query to get paginated unique snippets
         inner_params = [repo_url]
@@ -79,29 +90,26 @@ class SqliteUiClient(UiClient, SqliteClient):
             all_discoveries.append(dict(Discovery(*result)._asdict()))
             result = cursor.fetchone()
 
-        # BUG: fix sorting (no enum in sqlite)
         return total_discoveries, all_discoveries
 
     def get_discoveries_count(self, repo_url=None, file_name=None, where=None):
-        """ Get all the discoveries of a repository.
+        """ Get the toal number of discoveries.
 
         Parameters
         ----------
-        repo_url: str
-            The url of the repository
+        repo_url: str, optional
+            The url of the repository. (returns the total number of discoveries
+            in the database if not provided)
         file_name: str, optional
-            The filename to filter discoveries on
-        TODO: docs
+            The name of the file to filter discoveries on
+        where: str, optional
+            Part of text contained in the snippet to filter discoveries on
+            (using SQL LIKE clause)
 
         Returns
         -------
-        list
-            A list of discoveries (dictionaries)
-
-        Raises
-        ------
-            TypeError
-                If any of the required arguments is missing
+        int
+            The total number of discoveries
         """
         query = 'SELECT COUNT(*) FROM discoveries'
         params = []

--- a/ui/backend/client_ui_sqlite.py
+++ b/ui/backend/client_ui_sqlite.py
@@ -1,5 +1,4 @@
-from credentialdigger import Client, SqliteClient
-from psycopg2 import Error, connect
+from credentialdigger import SqliteClient
 
 from .client_ui import UiClient
 
@@ -46,3 +45,29 @@ class SqliteUiClient(UiClient, SqliteClient):
             params.append(order_by, order_direction)
 
         return super().get_discoveries(query, params)
+
+    def get_files_summary(self, repo_url):
+        """ Get aggregated discoveries info on all files of a repository.
+
+        Parameters
+        ----------
+        repo_url: str
+            The url of the repository
+
+        Returns
+        -------
+        list
+            A list of files with aggregated data (dictionaries)
+        """
+        return super().get_files_summary(
+            repo_url=repo_url,
+            query=(
+                "SELECT file_name,"
+                " COUNT(*) AS tot_discoveries,"
+                " COUNT(CASE WHEN state='new' THEN 1 END) AS new,"
+                " COUNT(CASE WHEN state='false_positive' THEN 1 END) AS false_positives,"
+                " COUNT(CASE WHEN state='addressing' THEN 1 END) AS addressing,"
+                " COUNT(CASE WHEN state='not_relevant' THEN 1 END) AS not_relevant"
+                " FROM discoveries WHERE repo_url=?"
+                " GROUP BY file_name"
+            ))

--- a/ui/res/js/discoveries.js
+++ b/ui/res/js/discoveries.js
@@ -77,7 +77,7 @@ function initDiscoveriesDataTable() {
   $('#discoveries-table').DataTable({
     ...defaultTableSettings,
     serverSide: true,
-    order: [[3, "desc"]], // Set default column sorting
+    order: [[3, "asc"]], // Set default column sorting
     columns: [ // Table columns definition
       {
         data: null,

--- a/ui/res/js/discoveries.js
+++ b/ui/res/js/discoveries.js
@@ -116,7 +116,7 @@ function initDiscoveriesDataTable() {
         ...filename && { file: filename }
       },
       dataSrc: function (json) {
-        return json.map(item => {
+        return json.data.map(item => {
           // Map json data before sending it to datatable
           const details = `
           <div>
@@ -160,8 +160,7 @@ function initDiscoveriesDataTable() {
       }
     },
     initComplete: function (settings, json) {
-      const totalDiscoveries = json.reduce((sum, currItem) =>
-        sum + currItem.occurrences.length, 0)
+      const totalDiscoveries = json.recordsTotal;
       document.querySelector('#discoveriesCounter').innerText = totalDiscoveries;
     }
   });

--- a/ui/res/js/discoveries.js
+++ b/ui/res/js/discoveries.js
@@ -81,6 +81,7 @@ function initDiscoveriesDataTable() {
   const filename = document.querySelector('#file-name').innerText;
   $('#discoveries-table').DataTable({
     ...defaultTableSettings,
+    serverSide: true,
     order: [[3, "desc"]], // Set default column sorting
     columns: [ // Table columns definition
       {
@@ -98,6 +99,7 @@ function initDiscoveriesDataTable() {
         className: "dt-center nowrap",
       }, {
         data: "tot",
+        orderable: false,
         className: "dt-center nowrap",
       }, {
         data: "occurrences",

--- a/ui/res/js/discoveries.js
+++ b/ui/res/js/discoveries.js
@@ -64,11 +64,6 @@ function initFilesDataTable() {
           }
         });
       }
-    },
-    initComplete: function (settings, json) {
-      const totalDiscoveries = json.reduce((sum, currItem) =>
-        sum + currItem.tot_discoveries, 0)
-      document.querySelector('#discoveriesCounter').innerText = totalDiscoveries;
     }
   });
 }
@@ -158,10 +153,6 @@ function initDiscoveriesDataTable() {
           }
         })
       }
-    },
-    initComplete: function (settings, json) {
-      const totalDiscoveries = json.recordsTotal;
-      document.querySelector('#discoveriesCounter').innerText = totalDiscoveries;
     }
   });
 }

--- a/ui/server.py
+++ b/ui/server.py
@@ -16,7 +16,7 @@ if os.getenv("LOCAL_REPO") == 'True':
     # Load credentialdigger from local repo instead of pip
     sys.path.insert(0, os.path.join(APP_ROOT, '..'))
 
-from credentialdigger import PgClient, SqliteClient  # noqa
+from backend import PgUiClient, SqliteUiClient  # noqa
 
 app = Flask('__name__', static_folder=os.path.join(APP_ROOT, './res'),
             template_folder=os.path.join(APP_ROOT, './templates'))
@@ -25,14 +25,14 @@ app.config['DEBUG'] = True  # Remove this line in production
 
 if os.getenv('USE_PG') == 'True':
     app.logger.info('Use Postgres Client')
-    c = PgClient(dbname=os.getenv('POSTGRES_DB'),
-                 dbuser=os.getenv('POSTGRES_USER'),
-                 dbpassword=os.getenv('POSTGRES_PASSWORD'),
-                 dbhost=os.getenv('DBHOST'),
-                 dbport=os.getenv('DBPORT'))
+    c = PgUiClient(dbname=os.getenv('POSTGRES_DB'),
+                   dbuser=os.getenv('POSTGRES_USER'),
+                   dbpassword=os.getenv('POSTGRES_PASSWORD'),
+                   dbhost=os.getenv('DBHOST'),
+                   dbport=os.getenv('DBPORT'))
 else:
     app.logger.info('Use Sqlite Client')
-    c = SqliteClient(path=os.path.join(APP_ROOT, './data.db'))
+    c = SqliteUiClient(path=os.path.join(APP_ROOT, './data.db'))
 c.add_rules_from_file(os.path.join(APP_ROOT, './backend/rules.yml'))
 
 

--- a/ui/server.py
+++ b/ui/server.py
@@ -257,7 +257,7 @@ def get_discoveries():
     response = {
         "recordsTotal": discoveries_count,
         "recordsFiltered": discoveries_count,
-        "data": [
+        "data": sorted([
             {
                 "snippet": keys[0],
                 "category": keys[1],
@@ -273,7 +273,7 @@ def get_discoveries():
             }
             for keys, values in groupby(
                 discoveries, lambda i: (i["snippet"], i["category"], i["state"]))
-        ]
+        ], key=lambda i: i[order_by], reverse=order_direction == 'asc')
     }
 
     return jsonify(response)

--- a/ui/server.py
+++ b/ui/server.py
@@ -232,11 +232,18 @@ def get_files():
 def get_discoveries():
     # Get all the discoveries of this repository
     url = request.args.get('url')
-    file = request.args.get('file')
-    if file is None:
-        discoveries = c.get_discoveries(url)
-    else:
-        discoveries = c.get_discoveries(url, file)
+    file_name = request.args.get('file')
+    where = request.args['search[value]']
+    where = where if len(where) > 0 else None
+    limit = int(request.args['length'])
+    offset = int(request.args['start'])
+    order_by_index = request.args['order[0][column]']
+    order_by = request.args[f'columns[{order_by_index}][data]']
+    order_direction = request.args['order[0][dir]']
+
+    discoveries = c.get_discoveries(
+        repo_url=url, file_name=file_name, where=where, limit=limit,
+        offset=offset, order_by=order_by, order_direction=order_direction)
 
     rulesdict, cat = _get_rules()
 

--- a/ui/server.py
+++ b/ui/server.py
@@ -82,13 +82,14 @@ def root():
 def files():
     # Get all the discoveries of this repository
     url = request.args.get('url')
-
     rulesdict, cat = _get_rules()
+    discoveries_count = c.get_discoveries_count(repo_url=url)
     active_scans = _get_active_scans()
     scanning = url in active_scans
 
     return render_template('discoveries/files.html',
                            url=url,
+                           discoveries_count=discoveries_count,
                            scanning=scanning,
                            categories=list(cat))
 
@@ -99,7 +100,7 @@ def discoveries():
     url = request.args.get('url')
     file = request.args.get('file')
     rulesdict, cat = _get_rules()
-
+    discoveries_count = c.get_discoveries_count(repo_url=url, file_name=file)
     active_scans = _get_active_scans()
     scanning = url in active_scans
 
@@ -107,11 +108,13 @@ def discoveries():
         return render_template('discoveries/file.html',
                                url=url,
                                file=file,
+                               discoveries_count=discoveries_count,
                                scanning=scanning,
                                categories=list(cat))
     else:
         return render_template('discoveries/discoveries.html',
                                url=url,
+                               discoveries_count=discoveries_count,
                                scanning=scanning,
                                categories=list(cat))
 

--- a/ui/templates/discoveries/discoveries.html
+++ b/ui/templates/discoveries/discoveries.html
@@ -39,7 +39,7 @@
 </div>
 
 <div class="topicHeaderWrapper underTopicHeaderWrapper">
-  <h3 class="scanDescription"><span id="discoveriesCounter"></span> discoveries found</h3>
+  <h3 class="scanDescription"><span id="discoveriesCounter">{{discoveries_count}}</span> discoveries found</h3>
 </div>
 
 <table id="discoveries-table" class="dataTable" style="width: 100%">

--- a/ui/templates/discoveries/file.html
+++ b/ui/templates/discoveries/file.html
@@ -52,7 +52,7 @@
 </div>
 
 <div class="topicHeaderWrapper underTopicHeaderWrapper">
-  <h3 class="scanDescription"><span id="discoveriesCounter"></span> discoveries found</h3>
+  <h3 class="scanDescription"><span id="discoveriesCounter">{{discoveries_count}}</span> discoveries found</h3>
 </div>
 
 <table id="discoveries-table" class="dataTable" style="width: 100%">

--- a/ui/templates/discoveries/files.html
+++ b/ui/templates/discoveries/files.html
@@ -39,7 +39,7 @@
 </div>
 
 <div class="topicHeaderWrapper underTopicHeaderWrapper">
-  <h3 class="scanDescription"><span id="discoveriesCounter"></span> discoveries found</h3>
+  <h3 class="scanDescription"><span id="discoveriesCounter">{{discoveries_count}}</span> discoveries found</h3>
 </div>
 <table id="files-table" class="dataTable" style="width: 100%">
   <!-- Header -->


### PR DESCRIPTION
In this PR `client.py`, `client_postgres.py`, and `client_sqlite.py` get extended to add more functionality to the UI, without affecting the main package code.
This is achieved by creating three new classes (`client_ui.py`, `client_ui_postgres.py`, and `client_ui_sqlite.py` in the `ui/` folder), which inherit from the main client classes.

As a use case for the need for separate classes in the main package and the UI, this PR also adds full pagination for the discoveries view, which brings down the loading time of the webpage by several seconds (based on the size of the repository).

A query for the total number of discoveries has also been created, in order to optimize loading times on the home page (using a SQL `COUNT` clause instead of selecting all discoveries and counting them from python).