### PR TITLE
Fix git token handling in UI

### DIFF
--- a/ui/backend/client_ui.py
+++ b/ui/backend/client_ui.py
@@ -57,7 +57,7 @@ class UiClient(Client):
             result = cursor.fetchone()
         return files
 
-    def check_git_token(self, repo_url, git_token):
+    def check_connection(self, repo_url, git_token=None):
         """
         Check git token validity for the repository
 
@@ -65,7 +65,7 @@ class UiClient(Client):
         ----------
         repo_url: str
             The url of the repository
-        git_token: str
+        git_token: str, optional
             Git personal access token to authenticate to the git server
 
         Returns
@@ -74,9 +74,10 @@ class UiClient(Client):
             True if the git token is valid for the repository, False otherwise
         """
         g = git.cmd.Git()
+        if git_token is not None and len(git_token) > 0:
+            repo_url = repo_url.replace('https://', f'https://{git_token}@')
         try:
-            g.ls_remote(repo_url.replace(
-                'https://', f'https://{git_token}@'))
+            g.ls_remote(repo_url)
         except GitCommandError:
             return False
         return True

--- a/ui/backend/client_ui.py
+++ b/ui/backend/client_ui.py
@@ -1,7 +1,9 @@
 from abc import abstractmethod
 from collections import namedtuple
 
+import git
 from credentialdigger import Client
+from git import GitCommandError
 
 FilesSummary = namedtuple(
     'FilesSummary',
@@ -54,3 +56,27 @@ class UiClient(Client):
             files.append(dict(FilesSummary(*result)._asdict()))
             result = cursor.fetchone()
         return files
+
+    def check_git_token(self, repo_url, git_token):
+        """
+        Check git token validity for the repository
+
+        Parameters
+        ----------
+        repo_url: str
+            The url of the repository
+        git_token: str
+            Git personal access token to authenticate to the git server
+
+        Returns
+        -------
+        bool
+            True if the git token is valid for the repository, False otherwise
+        """
+        g = git.cmd.Git()
+        try:
+            g.ls_remote(repo_url.replace(
+                'https://', f'https://{git_token}@'))
+        except GitCommandError:
+            return False
+        return True

--- a/ui/res/css/repos.css
+++ b/ui/res/css/repos.css
@@ -83,6 +83,16 @@ td.last-scan {
   font-size: 14px;
 }
 
+#startRepoScan .loader {
+  width: 15px;
+  height: 15px;
+  border-width: 2px;
+}
+
+#startRepoScan .loaderWrapper {
+  margin-left: 10px;
+}
+
 @media (max-width: 767px) {
   .generalInfoLinkCounter {
     font-size: 30px;

--- a/ui/res/js/scanForm.js
+++ b/ui/res/js/scanForm.js
@@ -44,15 +44,34 @@ function initScanRepo() {
       method: 'POST',
       data: $(this).serialize(),
       beforeSend: function() {
-        document.querySelector('#scan_repo')?.reset();
+        const scanBtn = document.querySelector('#startRepoScan');
+        scanBtn.classList.add('disabled');
+        scanBtn.disabled = true;
+        scanBtn.insertAdjacentHTML('beforeend', '<div class="loaderWrapper"><div class="loader"></div></div>');
       },
       success: function() {
         // close popup and open ok modal
         document.querySelector('#addRepoModal').classList.remove('open');
+        
+        const scanBtn = document.querySelector('#startRepoScan');
+        scanBtn.classList.remove('disabled');
+        scanBtn.disabled = false;
+        scanBtn.querySelector('.loaderWrapper').remove();
+
+        document.querySelector('#scan_repo')?.reset();
         if($('#repos-table')) $('#repos-table').DataTable().ajax.reload();
         if(document.querySelector('#newScan')) {
           getScan();
           scanInterval = setInterval(getScan, POLLING_INTERVAL);
+        }
+      },
+      statusCode: {
+        401: function() {
+          addError(document.querySelector('#gitTokenInput'), 'Git token not valid');
+          const scanBtn = document.querySelector('#startRepoScan');
+          scanBtn.classList.remove('disabled');
+          scanBtn.disabled = false;
+          scanBtn.querySelector('.loaderWrapper').remove();
         }
       }
     });

--- a/ui/server.py
+++ b/ui/server.py
@@ -183,6 +183,9 @@ def scan_repo():
     force_scan = request.form.get('forceScan') == 'force'
     git_token = request.form.get('gitToken')
 
+    if not c.check_git_token(repo_link, git_token):
+        return f'Git token not valid for repository {repo_link}', 401
+
     # Set up models
     models = []
     if use_path_model == 'path':

--- a/ui/server.py
+++ b/ui/server.py
@@ -183,7 +183,7 @@ def scan_repo():
     force_scan = request.form.get('forceScan') == 'force'
     git_token = request.form.get('gitToken')
 
-    if not c.check_git_token(repo_link, git_token):
+    if not c.check_connection(repo_link, git_token):
         return f'Git token not valid for repository {repo_link}', 401
 
     # Set up models


### PR DESCRIPTION
This PR handles the situation where the git token used for the scan is not valid for the chosen repository (either it is blank or does not the access rights).

This is handled by the `check_git_token` function in the `client_ui.py`, as I found it to be the less painful way, given that the code that tries to clone the repository is in a thread and therefore cannot communicate with the main thread easily (i.e. the `/scan_repo` POST request).

On the UI side, when the user clicks on the `Scan repo` button in the scan form modal (and therefore submits the form), a loader will appear in the button and the check will start. Once the check is finished, the loader is removed and:
* the modal hides if the check was successful
* an error will appear below the input field otherwise

The check is made with an `ls-remote` command on the repo, which I found to be the quickest way to check for the repo connection without actually cloning it.
