### PR TITLE
Local repo scans

### DIFF
--- a/credentialdigger/cli/scan.py
+++ b/credentialdigger/cli/scan.py
@@ -65,14 +65,19 @@ def configure_parser(parser):
     parser.set_defaults(func=run)
     parser.add_argument(
         'repo_url', type=str,
-        help='The URL of the git repository to be scanned.')
+        help='The location of a git repository (an url if local_repo is False, \
+            a local path otherwise)')
+    parser.add_argument(
+        '--local', action='store_true',
+        help='If True, get the repository from a local directory instead of \
+            the web'
+    )
     parser.add_argument(
         '--force', action='store_true',
         help='Force a complete re-scan of the repository, in case it has \
             already been scanned previously')
     parser.add_argument(
-        '--generate_snippet_extractor',
-        action='store_true',
+        '--generate_snippet_extractor', action='store_true',
         help='Generate the extractor model to be used in the SnippetModel. \
             The extractor is generated using the ExtractorGenerator. If \
             `False`, use the pre-trained extractor model')
@@ -105,6 +110,7 @@ def run(client, args):
         force=args.force,
         debug=args.debug,
         generate_snippet_extractor=args.generate_snippet_extractor,
-        git_token=args.git_token)
+        git_token=args.git_token,
+        local_repo=args.local)
 
     sys.exit(len(discoveries))

--- a/credentialdigger/cli/scan.py
+++ b/credentialdigger/cli/scan.py
@@ -10,12 +10,13 @@ usage: credentialdigger scan [-h] [--dotenv DOTENV] [--sqlite SQLITE]
                              [--category CATEGORY]
                              [--models MODELS [MODELS ...]]
                              [--exclude EXCLUDE [EXCLUDE ...]] [--debug]
-                             [--git_token GIT_TOKEN] [--force]
+                             [--git_token GIT_TOKEN] [--local] [--force]
                              [--generate_snippet_extractor]
                              repo_url
 
 positional arguments:
-  repo_url              The URL of the git repository to be scanned.
+  repo_url              The location of a git repository (an url if --local is
+                        not set, a local path otherwise)
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -38,6 +39,8 @@ optional arguments:
   --git_token GIT_TOKEN
                         Git personal access token to authenticate to the git
                         server
+  --local               If True, get the repository from a local directory
+                        instead of the web
   --force               Force a complete re-scan of the repository, in case it
                         has already been scanned previously
   --generate_snippet_extractor
@@ -45,7 +48,6 @@ optional arguments:
                         SnippetModel. The extractor is generated using the
                         ExtractorGenerator. If `False`, use the pre-trained
                         extractor model
-
 """
 import logging
 import sys
@@ -65,7 +67,7 @@ def configure_parser(parser):
     parser.set_defaults(func=run)
     parser.add_argument(
         'repo_url', type=str,
-        help='The location of a git repository (an url if local_repo is False, \
+        help='The location of a git repository (an url if --local is not set, \
             a local path otherwise)')
     parser.add_argument(
         '--local', action='store_true',

--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -460,7 +460,7 @@ class Client(Interface):
             The new state of these discoveries
         repo_url: str
             The url of the repository
-        file_name: str
+        file_name: str, optional
             The name of the file
         snippet: str, optional
             The snippet

--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -244,7 +244,7 @@ class Client(Interface):
         Parameters
         ----------
         repo_url: str
-            The url of the repo
+            The url of the repository
 
         Returns
         -------
@@ -509,8 +509,8 @@ class Client(Interface):
             use the pre-trained extractor model
         scanner: class, default: `GitScanner`
             The class of the scanner, a subclass of `scanners.BaseScanner`
-        scanner_kwargs: args
-            Keyword arguments to pass to the scanner
+        scanner_kwargs: kwargs
+            Keyword arguments to be passed to the scanner
 
         Returns
         -------
@@ -592,6 +592,8 @@ class Client(Interface):
             latest_timestamp, these_discoveries = s.scan(
                 repo_url, since_timestamp=from_timestamp, **scanner_kwargs)
         except Exception as e:
+            # If the scan raises an exception, remove the newly added repo
+            # before bubbling the exception
             if new_repo:
                 self.delete_repo(repo_url)
             raise e

--- a/credentialdigger/client_postgres.py
+++ b/credentialdigger/client_postgres.py
@@ -190,7 +190,7 @@ class PgClient(Client):
         Parameters
         ----------
         repo_url: str
-            The url of the repo
+            The url of the repository
 
         Returns
         -------

--- a/credentialdigger/client_sqlite.py
+++ b/credentialdigger/client_sqlite.py
@@ -208,7 +208,7 @@ class SqliteClient(Client):
         Parameters
         ----------
         repo_url: str
-            The url of the repo
+            The url of the repository
 
         Returns
         -------

--- a/credentialdigger/scanners/base_scanner.py
+++ b/credentialdigger/scanners/base_scanner.py
@@ -1,7 +1,4 @@
-import tempfile
 from abc import ABC, abstractmethod
-
-from git import Repo as GitRepo
 
 
 class BaseScanner(ABC):
@@ -12,9 +9,3 @@ class BaseScanner(ABC):
     @abstractmethod
     def scan(self, repo_url, **kwargs):
         pass
-
-    def clone_git_repo(self, git_url):
-        """ Clone git repository. """
-        project_path = tempfile.mkdtemp()
-        GitRepo.clone_from(git_url, project_path)
-        return project_path

--- a/credentialdigger/scanners/git_scanner.py
+++ b/credentialdigger/scanners/git_scanner.py
@@ -1,13 +1,17 @@
 import hashlib
+import logging
 import re
 import shutil
+import tempfile
 from datetime import datetime, timezone
 
 import hyperscan
-from git import NULL_TREE
+from git import NULL_TREE, GitCommandError, InvalidGitRepositoryError
 from git import Repo as GitRepo
 
 from .base_scanner import BaseScanner
+
+logger = logging.getLogger(__name__)
 
 
 class GitScanner(BaseScanner):
@@ -49,17 +53,72 @@ class GitScanner(BaseScanner):
                              elements=len(patterns),
                              flags=flags)
 
-    def scan(self, git_url, since_timestamp=0, max_depth=1000000):
+    def get_git_repo(self, repo_url, local_repo):
+        """ Get a git repository.
+
+        Parameters
+        ----------
+        repo_url: string
+            The location (an url if local is False, a local path otherwise) of
+            a git repository
+        local_repo: bool
+            If True, get the repository from a local directory instead of the
+            web
+
+        Returns
+        -------
+        str
+            The temporary path to which the repository has been copied
+        GtiRepo
+            The repository object
+
+        Raises
+        ------
+        git.InvalidGitRepositoryError
+            If the directory in repo_url is not a git repository
+        git.GitCommandError
+            If the url in repo_url is not a git repository, or access to the
+            repository is denied
+        """
+        project_path = tempfile.mkdtemp()
+        if local_repo:
+            try:
+                shutil.copytree(repo_url, project_path, dirs_exist_ok=True)
+                repo = GitRepo(project_path)
+            except (FileNotFoundError, InvalidGitRepositoryError) as e:
+                logger.error(
+                    f"Path \"{repo_url}\" is not a local git repository.")
+                shutil.rmtree(project_path)
+                raise e
+        else:
+            try:
+                GitRepo.clone_from(repo_url, project_path)
+                repo = GitRepo(project_path)
+            except GitCommandError as e:
+                logger.error(f"Authentication failed for url \"{repo_url}\".")
+                shutil.rmtree(project_path)
+                raise e
+
+        return project_path, repo
+
+    def scan(self, repo_url, since_timestamp=0, max_depth=1000000,
+             git_token=None, local_repo=False):
         """ Scan a repository.
 
         Parameters
         ----------
-        git_url: string
-            The url of a git repository
+        repo_url: string
+            The location of a git repository (an url if local_repo is False, a
+            local path otherwise)
         since_timestamp: int, optional
             The oldest timestamp to scan
         max_depth: int, optional
             The maximum number of commits to scan
+        git_token: str, optional
+            Git personal access token to authenticate to the git server
+        local_repo: bool
+            If True, get the repository from a local directory instead of the
+            web
 
         Returns
         -------
@@ -69,8 +128,12 @@ class GitScanner(BaseScanner):
             A list of discoveries (dictionaries). If there are no discoveries
             return an empty list
         """
-        project_path = self.clone_git_repo(git_url)
-        repo = GitRepo(project_path)
+        if git_token:
+            logger.debug('Authenticate user with token')
+            repo_url = repo_url.replace('https://',
+                                        f'https://oauth2:{git_token}@')
+
+        project_path, repo = self.get_git_repo(repo_url, local_repo)
 
         already_searched = set()
         discoveries = []

--- a/credentialdigger/scanners/git_scanner.py
+++ b/credentialdigger/scanners/git_scanner.py
@@ -59,8 +59,8 @@ class GitScanner(BaseScanner):
         Parameters
         ----------
         repo_url: str
-            The location (an url if local is False, a local path otherwise) of
-            a git repository
+            The location of the git repository (an url if local is False, a
+            local path otherwise)
         local_repo: bool
             If True, get the repository from a local directory instead of the
             web
@@ -74,6 +74,8 @@ class GitScanner(BaseScanner):
 
         Raises
         ------
+        FileNotFoundError
+            If repo_url is not an existing directory
         git.InvalidGitRepositoryError
             If the directory in repo_url is not a git repository
         git.GitCommandError
@@ -97,7 +99,6 @@ class GitScanner(BaseScanner):
                 GitRepo.clone_from(repo_url, project_path)
                 repo = GitRepo(project_path)
             except GitCommandError as e:
-                logger.error(f"Authentication failed for url \"{repo_url}\".")
                 shutil.rmtree(project_path)
                 raise e
 

--- a/credentialdigger/scanners/git_scanner.py
+++ b/credentialdigger/scanners/git_scanner.py
@@ -58,7 +58,7 @@ class GitScanner(BaseScanner):
 
         Parameters
         ----------
-        repo_url: string
+        repo_url: str
             The location (an url if local is False, a local path otherwise) of
             a git repository
         local_repo: bool
@@ -85,11 +85,13 @@ class GitScanner(BaseScanner):
             try:
                 shutil.copytree(repo_url, project_path, dirs_exist_ok=True)
                 repo = GitRepo(project_path)
-            except (FileNotFoundError, InvalidGitRepositoryError) as e:
-                logger.error(
-                    f"Path \"{repo_url}\" is not a local git repository.")
+            except FileNotFoundError as e:
                 shutil.rmtree(project_path)
                 raise e
+            except InvalidGitRepositoryError as e:
+                shutil.rmtree(project_path)
+                raise InvalidGitRepositoryError(
+                    f"\"{repo_url}\" is not a local git repository.") from e
         else:
             try:
                 GitRepo.clone_from(repo_url, project_path)
@@ -107,7 +109,7 @@ class GitScanner(BaseScanner):
 
         Parameters
         ----------
-        repo_url: string
+        repo_url: str
             The location of a git repository (an url if local_repo is False, a
             local path otherwise)
         since_timestamp: int, optional
@@ -116,7 +118,7 @@ class GitScanner(BaseScanner):
             The maximum number of commits to scan
         git_token: str, optional
             Git personal access token to authenticate to the git server
-        local_repo: bool
+        local_repo: bool, optional
             If True, get the repository from a local directory instead of the
             web
 

--- a/ui/backend/client_ui.py
+++ b/ui/backend/client_ui.py
@@ -3,7 +3,8 @@ from collections import namedtuple
 
 import git
 from credentialdigger import Client
-from git import GitCommandError
+from git import GitCommandError, InvalidGitRepositoryError, NoSuchPathError
+from git import Repo as GitRepo
 
 FilesSummary = namedtuple(
     'FilesSummary',
@@ -57,28 +58,40 @@ class UiClient(Client):
             result = cursor.fetchone()
         return files
 
-    def check_connection(self, repo_url, git_token=None):
+    def check_repo(self, repo_url, git_token=None, local_repo=False):
         """
         Check git token validity for the repository
 
         Parameters
         ----------
         repo_url: str
-            The url of the repository
+            The location of a git repository (an url if local_repo is False, a
+            local path otherwise)
         git_token: str, optional
             Git personal access token to authenticate to the git server
+        local_repo: bool, optional
+            If True, get the repository from a local directory instead of the
+            web
 
         Returns
         -------
         bool
             True if the git token is valid for the repository, False otherwise
         """
-        g = git.cmd.Git()
-        if git_token is not None and len(git_token) > 0:
-            repo_url = repo_url.replace('https://',
-                                        f'https://oauth2:{git_token}@')
-        try:
-            g.ls_remote(repo_url)
-        except GitCommandError:
-            return False
-        return True
+        if local_repo:
+            try:
+                GitRepo(repo_url)
+            except InvalidGitRepositoryError:
+                return False, 'InvalidGitRepositoryError'
+            except NoSuchPathError:
+                return False, 'NoSuchPathError'
+        else:
+            g = git.cmd.Git()
+            if git_token is not None and len(git_token) > 0:
+                repo_url = repo_url.replace('https://',
+                                            f'https://oauth2:{git_token}@')
+            try:
+                g.ls_remote(repo_url)
+            except GitCommandError:
+                return False, 'GitCommandError'
+        return True, None

--- a/ui/res/css/repos.css
+++ b/ui/res/css/repos.css
@@ -60,23 +60,23 @@ td.dtr-control {
   text-overflow: ellipsis;
 }
 
-td .github {
+td .repo-icon {
   text-decoration: none;
-  margin-left: 10px;
+  margin-left: 1px;
   vertical-align: middle;
   font-size: 18px;
-  margin-right: 10px;
-  display: none;
-  transition: color .1s ease-out;
+  margin-right: 8px;
+  transition: all .15s ease-out;
 }
 
-.dataTable td.filename a.github:hover {
+td .repo-icon.icon-folder_open {
+  font-size: 20px;
+}
+
+.dataTable td.filename a.repo-icon:hover {
   color: #999;
 }
 
-.dataTable td.filename:hover .github {
-  display: block;
-}
 
 td.last-scan {
   white-space: nowrap;

--- a/ui/res/js/repos.js
+++ b/ui/res/js/repos.js
@@ -49,13 +49,16 @@ function initReposDataTable() {
         document.querySelector('#allDiscoveries').innerText = json.reduce((prev, curr) => prev + curr.lendiscoveries, 0);
         // Map json data before sending it to datatable
         return json.map(item => {
+          local_repo = !(item.url.startsWith('http://') || item.url.startsWith('https://'));
           return {
             ...item,
             last_scan: item.last_scan ? timestampToDate(item.last_scan) : 'Never',
             url: `
               <div>
+                ${local_repo ?
+                `<span class="icon icon-folder_open repo-icon"></span>` :
+                `<a target="_blank" href="${item.url}" class="icon icon-github repo-icon"></a>`}
                 <span>${item.url}</span>
-                <a target="_blank" href="${item.url}" class="icon icon-github github"></a>
               </div>`,
             scan_active: item.scan_active ? `
               <span class="icon icon-timelapse warning-color"></span>

--- a/ui/server.py
+++ b/ui/server.py
@@ -182,9 +182,12 @@ def scan_repo():
     # then 'forceScan' will be set to False; thus, ignored.
     force_scan = request.form.get('forceScan') == 'force'
     git_token = request.form.get('gitToken')
+    local_repo = not (repo_link.startswith(
+        'http://') or repo_link.startswith('https://'))
 
-    if not c.check_connection(repo_link, git_token):
-        return f'Git token not valid for repository {repo_link}', 401
+    url_is_valid, err_code = c.check_repo(repo_link, git_token, local_repo)
+    if not url_is_valid:
+        return err_code, 401
 
     # Set up models
     models = []
@@ -198,7 +201,8 @@ def scan_repo():
         "repo_url": repo_link,
         "models": models,
         "force": force_scan,
-        "git_token": git_token
+        "git_token": git_token,
+        "local_repo": local_repo
     }
     if rules_to_use != 'all':
         args["category"] = rules_to_use

--- a/ui/templates/discoveries/discoveries.html
+++ b/ui/templates/discoveries/discoveries.html
@@ -7,10 +7,17 @@
     <span class="icon icon-keyboard_arrow_left"></span>
     <span class="link-text">Go back to all repos</span>
   </a>
+  {% if url.startswith('http://') or url.startswith('https://') %}
   <a href="{{url}}" class="repo-link" target="_blank" title="{{url}}">
     <span class="icon icon-github"></span>
     <span class="link-text">{{url}}</span>
   </a>
+  {% else %}
+  <span class="repo-link" title="{{url}}">
+    <span class="icon icon-folder_open"></span>
+    <span class="link-text">{{url}}</span>
+  </a>
+  {% endif %}
 </div>
 
 <!--discoveries list with search bar-->

--- a/ui/templates/discoveries/file.html
+++ b/ui/templates/discoveries/file.html
@@ -7,10 +7,17 @@
     <span class="icon icon-keyboard_arrow_left"></span>
     <span class="link-text">Go back to all files</span>
   </a>
+  {% if url.startswith('http://') or url.startswith('https://') %}
   <a href="{{url}}" class="repo-link" target="_blank" title="{{url}}">
     <span class="icon icon-github"></span>
     <span class="link-text">{{url}}</span>
   </a>
+  {% else %}
+  <span class="repo-link" title="{{url}}">
+    <span class="icon icon-folder_open"></span>
+    <span class="link-text">{{url}}</span>
+  </a>
+  {% endif %}
 </div>
 
 <!--discoveries list with search bar-->

--- a/ui/templates/discoveries/files.html
+++ b/ui/templates/discoveries/files.html
@@ -7,10 +7,17 @@
     <span class="icon icon-keyboard_arrow_left"></span>
     <span class="link-text">Go back to all repos</span>
   </a>
-  <a href="{{url}}" target="_blank" class="repo-link">
+  {% if url.startswith('http://') or url.startswith('https://') %}
+  <a href="{{url}}" class="repo-link" target="_blank" title="{{url}}">
     <span class="icon icon-github"></span>
     <span class="link-text">{{url}}</span>
   </a>
+  {% else %}
+  <span class="repo-link" title="{{url}}">
+    <span class="icon icon-folder_open"></span>
+    <span class="link-text">{{url}}</span>
+  </a>
+  {% endif %}
 </div>
 
 <!--discoveries list with search bar-->

--- a/ui/templates/shared/_scanRepoModal.html
+++ b/ui/templates/shared/_scanRepoModal.html
@@ -14,7 +14,7 @@
         <input id="repoLinkInput" type="hidden" name="repolink" value="{{url}}">
       {% else %}
         <div class="form-item">
-          <input id="repoLinkInput" type="link" name="repolink" class="textInput" placeholder="GitHub Repo URL">
+          <input id="repoLinkInput" type="text" name="repolink" class="textInput" placeholder="GitHub Repo URL">
         </div>
       {% endif %}
       <p class="formLabel">Select category :</p>

--- a/ui/templates/shared/_scanRepoModal.html
+++ b/ui/templates/shared/_scanRepoModal.html
@@ -14,7 +14,7 @@
         <input id="repoLinkInput" type="hidden" name="repolink" value="{{url}}">
       {% else %}
         <div class="form-item">
-          <input id="repoLinkInput" type="text" name="repolink" class="textInput" placeholder="GitHub Repo URL">
+          <input id="repoLinkInput" type="text" name="repolink" class="textInput" placeholder="GitHub repo URL or local repo path">
         </div>
       {% endif %}
       <p class="formLabel">Select category :</p>


### PR DESCRIPTION
This PR brings local repository scans to the CLI and UI and aims to be a first step to solving #88.

In the **CLI**, the new boolean option `--local` is added: when such option is set, the `repo_url` argument is intended as a local path, in which the repo will be searched for.
In the **UI**, a hint text is placed in the placeholder of the repo URL input, to suggest that that field can also be a local path.

As discussed with @marcorosa, I avoided renaming the variable `repo_url` to something that would include also the meaning of path (e.g., `repo_uri` or `repo_location`), in order not to introduce breaking changes in the database again.

Additionally, the handling of `git_token` and other scanner-related parameters are now delegated to the scanner itself (e.g., `git_scanner.py`) instead of the scan method in `client.py`. This is done in view of the upcoming addition of a `file_scanner`, in order for the `scan` method to be scanner-indipendent.

A bug is also fixed in this PR, partially unrelated to the new feature. During the first scan of a repository, if an exception was raised by the scan method, the program would bubble up the exception and fail. However, the repository would still be inserted into the database. With this PR, if an exception is raised in the scan method and if the repository is new, it gets deleted from the db before bubbling the exception. 
