### PR TITLE
Suppress fasttext warnings when loading models

### DIFF
--- a/credentialdigger/models/base_model.py
+++ b/credentialdigger/models/base_model.py
@@ -5,6 +5,8 @@ import fasttext
 import pkg_resources
 import srsly
 
+fasttext.FastText.eprint = lambda x: None
+
 
 class BaseModel(ABC):
 


### PR DESCRIPTION
This is a quick PR to suppress the several fasttext warnings when loading ML models.
An example of said warning is:
```bash
Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.
```

The fix is taken from https://github.com/facebookresearch/fastText/issues/1067.
