### PR TITLE
[Feat/https] HTTPS Support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,7 +3,10 @@ POSTGRES_PASSWORD=
 POSTGRES_DB=
 DBHOST=postgres
 DBPORT=5432
+
 path_model=https://github.com/SAP/credential-digger/releases/download/PM-v1.0.1/path_model-1.0.1.tar.gz
 snippet_model=https://github.com/SAP/credential-digger/releases/download/SM-v1.0.0/snippet_model-1.0.0.tar.gz
-SSL_certificate=
-SSL_private_key=
+
+# Enable HTTPS by setting the path of both the certificate and the private key as shown below
+SSL_certificate=/credential-digger-ui/$PATH_to_certificate # i.e /credential-digger-ui/cert.pem
+SSL_private_key=/credential-digger-ui/$PATH_to_key # i.e /credential-digger-ui/key.pem

--- a/.env.sample
+++ b/.env.sample
@@ -3,10 +3,8 @@ POSTGRES_PASSWORD=
 POSTGRES_DB=
 DBHOST=postgres
 DBPORT=5432
-
 path_model=https://github.com/SAP/credential-digger/releases/download/PM-v1.0.1/path_model-1.0.1.tar.gz
 snippet_model=https://github.com/SAP/credential-digger/releases/download/SM-v1.0.0/snippet_model-1.0.0.tar.gz
-
 # Enable HTTPS by setting the path of both the certificate and the private key as shown below
-SSL_certificate=/credential-digger-ui/$PATH_to_certificate # i.e /credential-digger-ui/cert.pem
-SSL_private_key=/credential-digger-ui/$PATH_to_key # i.e /credential-digger-ui/key.pem
+SSL_certificate=PATH_to_certificate.pem
+SSL_private_key=PATH_to_key.pem

--- a/.env.sample
+++ b/.env.sample
@@ -5,3 +5,5 @@ DBHOST=postgres
 DBPORT=5432
 path_model=https://github.com/SAP/credential-digger/releases/download/PM-v1.0.1/path_model-1.0.1.tar.gz
 snippet_model=https://github.com/SAP/credential-digger/releases/download/SM-v1.0.0/snippet_model-1.0.0.tar.gz
+SSL_certificate=
+SSL_private_key=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       args:
         - path_model=$path_model
         - snippet_model=$snippet_model
+        - SSL_certificate=$SSL_certificate
+        - SSL_private_key=$SSL_private_key
     container_name: credential_digger_sqlite
     restart: always
     env_file:

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,16 +1,20 @@
 FROM python:3.7
 
 RUN pip install Flask python-dotenv
-RUN apt-get update && apt-get install -y libhyperscan5 libpq-dev
+RUN apt-get update && apt-get install -y libhyperscan5 libpq-dev gunicorn3
 
 # Don't verify ssl for github enterprise
 RUN git config --global http.sslverify false
 
 # Install Credential Digger
 RUN pip install credentialdigger
+# Install Gunicorn WSGI HTTP Server
+RUN pip install gunicorn
 
 ARG path_model
 ARG snippet_model
+ARG SSL_certificate
+ARG SSL_private_key
 
 COPY . /credential-digger-ui
 WORKDIR /credential-digger-ui/

--- a/ui/run.sh
+++ b/ui/run.sh
@@ -30,7 +30,7 @@ if [[ -z "${SSL_private_key}" ]]; then
 fi
 
 echo "Starting server..."
-if [ "$HTTPS" = true ]; then
+if [[ "$HTTPS" = true ]]; then
     echo "🔐 HTTPS will be used..."
     gunicorn -b 0.0.0.0:5000 wsgi:app --certfile $SSL_certificate --keyfile $SSL_private_key
 else

--- a/ui/run.sh
+++ b/ui/run.sh
@@ -2,7 +2,7 @@
 
 echo "Download models..."
 
-if [ -z "${path_model}" ]; then
+if [[ -z "${path_model}" ]]; then
     echo "Path model not provided"
 else
     echo "Running with path_model=$path_model"

--- a/ui/run.sh
+++ b/ui/run.sh
@@ -22,7 +22,6 @@ HTTPS=true
 if [[ -z "${SSL_certificate}" ]]; then
     # No certificate
     HTTPS=false
-
 fi
 
 if [[ -z "${SSL_private_key}" ]]; then

--- a/ui/run.sh
+++ b/ui/run.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "Download models..."
 
-if [[ -z "${path_model}" ]]; then
+if [ -z "${path_model}" ]; then
     echo "Path model not provided"
 else
     echo "Running with path_model=$path_model"
@@ -12,9 +12,29 @@ fi
 if [[ -z "${snippet_model}" ]]; then
     echo "Snippet model not provided"
 else
-    echo "Running with snippet_model=$snippet_model"
+    echo "Running with snipper_model=$snippet_model"
     python -m credentialdigger download snippet_model
 fi
 
+# Set HTTPS flag to True
+HTTPS=true
+
+if [[ -z "${SSL_certificate}" ]]; then
+    # No certificate
+    HTTPS=false
+
+fi
+
+if [[ -z "${SSL_private_key}" ]]; then
+    # No private key
+    HTTPS=false
+fi
+
 echo "Starting server..."
-python /credential-digger-ui/server.py
+if [ "$HTTPS" = true ]; then
+    echo "🔐 HTTPS will be used..."
+    gunicorn -b 0.0.0.0:5000 wsgi:app --certfile /credential-digger-ui$SSL_certificate --keyfile /credential-digger-ui$SSL_private_key
+else
+    echo "🔓 HTTPS will not be used... (HTTP only)"
+    gunicorn -b 0.0.0.0:5000 wsgi:app
+fi

--- a/ui/run.sh
+++ b/ui/run.sh
@@ -12,7 +12,7 @@ fi
 if [[ -z "${snippet_model}" ]]; then
     echo "Snippet model not provided"
 else
-    echo "Running with snipper_model=$snippet_model"
+    echo "Running with snippet_model=$snippet_model"
     python -m credentialdigger download snippet_model
 fi
 

--- a/ui/run.sh
+++ b/ui/run.sh
@@ -33,7 +33,7 @@ fi
 echo "Starting server..."
 if [ "$HTTPS" = true ]; then
     echo "🔐 HTTPS will be used..."
-    gunicorn -b 0.0.0.0:5000 wsgi:app --certfile /credential-digger-ui$SSL_certificate --keyfile /credential-digger-ui$SSL_private_key
+    gunicorn -b 0.0.0.0:5000 wsgi:app --certfile $SSL_certificate --keyfile $SSL_private_key
 else
     echo "🔓 HTTPS will not be used... (HTTP only)"
     gunicorn -b 0.0.0.0:5000 wsgi:app

--- a/ui/server.py
+++ b/ui/server.py
@@ -328,5 +328,5 @@ def update_discovery_group():
         return 'OK', 200
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)

--- a/ui/server.py
+++ b/ui/server.py
@@ -328,4 +328,5 @@ def update_discovery_group():
         return 'OK', 200
 
 
-app.run(host='0.0.0.0', port=5000)
+if __name__ == "__main__":
+    app.run(host='0.0.0.0', port=5000)

--- a/ui/wsgi.py
+++ b/ui/wsgi.py
@@ -1,0 +1,4 @@
+from server import app
+
+if __name__ == "__main__":
+    app.run(host='0.0.0.0', port=5000)

--- a/ui/wsgi.py
+++ b/ui/wsgi.py
@@ -1,4 +1,4 @@
 from server import app
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
### 🔐 HTTPS SUPPORT

A user can now easily run the web application over HTTPS. It is not mandatory, but it highly recommended.

#### How to
1. We assume you have a signed certificate (certificate.pem) and a private key (key.pem)
 a.  You can run this command to generate a certificate and private key: `openssl req -newkey rsa:2048 -new -nodes -x509 -days 365 -keyout key.pem -out cert.pem`
2. Set up the path of both the certificate and the key in your .env file
```bash
SSL_certificate=/credential-digger-ui/$PATH_to_certificate # i.e /credential-digger-ui/cert.pem
SSL_private_key=/credential-digger-ui/$PATH_to_key # i.e /credential-digger-ui/key.pem
```
3. Start the docker container
```bash
sudo docker-compose up --build
```
If everything works out just fine, you should get this output: `🔐 HTTPS will be used...`

If you leave the SSL variables in the .env file empty, the UI will run on HTTP as usual; resulting in the following output: `🔓 HTTPS will not be used... (HTTP only)`

### Important
Please make sure to make an exception to your self-signed certificate on the browser you are using. Having a warning message the first time you access the web page (i.e https://0.0.0.0:5000/) is a completely normal behavior because the certificate in use is not signed by a known Certificate Authority.

### Misc
Upon the acceptance of this PR, a wiki page will be set up to explain the process in more details for the users.