### PR TITLE
Feat/login: Secure UI connection

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,3 +8,5 @@ snippet_model=https://github.com/SAP/credential-digger/releases/download/SM-v1.0
 # Enable HTTPS by setting the path of both the certificate and the private key as shown below
 SSL_certificate=PATH_to_certificate.pem
 SSL_private_key=PATH_to_key.pem
+AUTH_KEY=admin # Password to be used to log in
+SECRET_KEY=# To be generated using python -c 'import os; print(os.urandom(24).hex())'

--- a/.env.sample
+++ b/.env.sample
@@ -5,7 +5,6 @@ DBHOST=postgres
 DBPORT=5432
 path_model=https://github.com/SAP/credential-digger/releases/download/PM-v1.0.1/path_model-1.0.1.tar.gz
 snippet_model=https://github.com/SAP/credential-digger/releases/download/SM-v1.0.0/snippet_model-1.0.0.tar.gz
-# Enable HTTPS by setting the path of both the certificate and the private key as shown below
 SSL_certificate=PATH_to_certificate.pem
 SSL_private_key=PATH_to_key.pem
 AUTH_KEY=admin

--- a/.env.sample
+++ b/.env.sample
@@ -8,5 +8,5 @@ snippet_model=https://github.com/SAP/credential-digger/releases/download/SM-v1.0
 # Enable HTTPS by setting the path of both the certificate and the private key as shown below
 SSL_certificate=PATH_to_certificate.pem
 SSL_private_key=PATH_to_key.pem
-AUTH_KEY=
+AUTH_KEY=admin
 SECRET_KEY=

--- a/.env.sample
+++ b/.env.sample
@@ -8,5 +8,5 @@ snippet_model=https://github.com/SAP/credential-digger/releases/download/SM-v1.0
 # Enable HTTPS by setting the path of both the certificate and the private key as shown below
 SSL_certificate=PATH_to_certificate.pem
 SSL_private_key=PATH_to_key.pem
-AUTH_KEY=admin # Password to be used to log in
-SECRET_KEY=# To be generated using python -c 'import os; print(os.urandom(24).hex())'
+AUTH_KEY=
+SECRET_KEY=

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7
 
-RUN pip install Flask python-dotenv
+RUN pip install flask_jwt_extended Flask python-dotenv
 RUN apt-get update && apt-get install -y libhyperscan5 libpq-dev gunicorn3
 
 # Don't verify ssl for github enterprise

--- a/ui/res/js/global.js
+++ b/ui/res/js/global.js
@@ -95,3 +95,24 @@ jQuery.fn.dataTable.Api.register( 'processing()', function ( show ) {
       ctx.oApi._fnProcessingDisplay( ctx, show );
   } );
 } );
+
+/**
+ * Handle the logout button
+ */
+ if (location.protocol !== 'http:') {
+  sessionStorage.setItem("logged_in", "True");
+  $(window).ready(function () {
+    logged_in = sessionStorage.getItem("logged_in");
+    if (logged_in == "True") {
+      logout_button = document.createElement('a');
+      logout_button.className = "headerItem headerLink"
+      logout_button.href = "/logout"
+      logout_button.innerHTML = "Logout"
+      document.getElementById('topRightButtons').appendChild(logout_button);
+      $('#topRightButtons').show();
+    }
+    else{
+      $('#topRightButtons').hide();
+    }
+  });
+}

--- a/ui/server.py
+++ b/ui/server.py
@@ -28,8 +28,7 @@ app.config['DEBUG'] = True  # Remove this line in production
 app.config['SECRET_KEY'] = os.getenv('SECRET_KEY')
 
 # HTTPS = True if both a certificate and private key exist, False otherwise.
-HTTPS = os.getenv('SSL_certificate') != '' and os.getenv(
-    'SSL_private_key') != ''
+HTTPS = os.getenv('SSL_certificate') and os.getenv('SSL_private_key')
 
 if os.getenv('USE_PG') == 'True':
     app.logger.info('Use Postgres Client')

--- a/ui/server.py
+++ b/ui/server.py
@@ -25,6 +25,11 @@ app = Flask('__name__', static_folder=os.path.join(APP_ROOT, './res'),
             template_folder=os.path.join(APP_ROOT, './templates'))
 app.config['UPLOAD_FOLDER'] = os.path.join(APP_ROOT, './backend')
 app.config['DEBUG'] = True  # Remove this line in production
+app.config['SECRET_KEY'] = os.getenv("SECRET_KEY")
+
+# HTTPS = True if both a certificate and private key exist, False otherwise.
+HTTPS = (os.getenv("SSL_certificate") !=
+         '' and os.getenv("SSL_private_key") != '')
 
 if os.getenv('USE_PG') == 'True':
     app.logger.info('Use Postgres Client')

--- a/ui/server.py
+++ b/ui/server.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import threading
+import uuid
 from collections import defaultdict
 from enum import Enum
 from itertools import groupby
@@ -14,7 +15,7 @@ from werkzeug.utils import secure_filename
 load_dotenv()
 
 APP_ROOT = os.path.dirname(os.path.abspath(__file__))
-if os.getenv("LOCAL_REPO") == 'True':
+if os.getenv('LOCAL_REPO') == 'True':
     # Load credentialdigger from local repo instead of pip
     sys.path.insert(0, os.path.join(APP_ROOT, '..'))
 
@@ -24,11 +25,11 @@ app = Flask('__name__', static_folder=os.path.join(APP_ROOT, './res'),
             template_folder=os.path.join(APP_ROOT, './templates'))
 app.config['UPLOAD_FOLDER'] = os.path.join(APP_ROOT, './backend')
 app.config['DEBUG'] = True  # Remove this line in production
-app.config['SECRET_KEY'] = os.getenv("SECRET_KEY")
+app.config['SECRET_KEY'] = os.getenv('SECRET_KEY')
 
 # HTTPS = True if both a certificate and private key exist, False otherwise.
-HTTPS = (os.getenv("SSL_certificate") !=
-         '' and os.getenv("SSL_private_key") != '')
+HTTPS = (os.getenv('SSL_certificate') !=
+         '' and os.getenv('SSL_private_key') != '')
 
 if os.getenv('USE_PG') == 'True':
     app.logger.info('Use Postgres Client')
@@ -74,8 +75,8 @@ registered_tokens = []
 @app.before_request
 def before_request():
     """
-        Treat all incoming requests before-hand. 
-        If the user is not yet logged in, he/she will be redirected towards the login page.
+    Treat all incoming requests before-hand. 
+    If the user is not yet logged in, he/she will be redirected towards the login page.
     """
     if(HTTPS):
         token = request.cookies.get('AUTH')
@@ -100,7 +101,6 @@ def login():
                 return render_template('login.html',
                                        msg='❌ Wrong key, please try again:')
             # We generate a UUID to be saved as a JWT's value
-            import uuid
             access_token = create_access_token(identity=str(uuid.uuid1()))
             resp = make_response(redirect(url_for('root')))
 

--- a/ui/server.py
+++ b/ui/server.py
@@ -67,6 +67,7 @@ def _get_rules():
 
     return rulesdict, cat
 
+# Store JWT value for every connected user
 registered_tokens = []
 
 @app.before_request

--- a/ui/server.py
+++ b/ui/server.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import sys
 import threading
@@ -7,7 +8,8 @@ from itertools import groupby
 
 import yaml
 from dotenv import load_dotenv
-from flask import Flask, jsonify, redirect, render_template, request, send_file
+from flask import Flask, jsonify, make_response, redirect, render_template, request, send_file, url_for
+from flask_jwt_extended import create_access_token, JWTManager
 from werkzeug.utils import secure_filename
 
 load_dotenv()

--- a/ui/server.py
+++ b/ui/server.py
@@ -67,7 +67,7 @@ def _get_rules():
     return rulesdict, cat
 
 
-# Store JWT value for every connected user
+# Store JWT's value for every connected user
 registered_tokens = []
 
 
@@ -99,7 +99,7 @@ def login():
                 redirect(url_for('login'))
                 return render_template('login.html',
                                        msg='❌ Wrong key, please try again:')
-            # We generate a UUID to be saved as a JWT
+            # We generate a UUID to be saved as a JWT's value
             import uuid
             access_token = create_access_token(identity=str(uuid.uuid1()))
             resp = make_response(redirect(url_for('root')))
@@ -109,7 +109,7 @@ def login():
             resp.set_cookie('AUTH', value=str(access_token), httponly=True,
                             secure=True)
 
-            # Store the new JWT value in the registered_tokens list
+            # Store the new JWT's value in the registered_tokens list
             registered_tokens.append(str(access_token))
             return resp
         else:
@@ -121,7 +121,7 @@ def login():
 @app.route('/logout')
 def logout():
     """
-    The user loses his access to the tool when his JWT no longer exists in the local
+    The user loses his access to the tool when his JWT's value no longer exists in the local
     registered_tokens list.
     """
     token = request.cookies.get('AUTH')

--- a/ui/server.py
+++ b/ui/server.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import sys
 import threading
@@ -67,14 +66,16 @@ def _get_rules():
 
     return rulesdict, cat
 
+
 # Store JWT value for every connected user
 registered_tokens = []
+
 
 @app.before_request
 def before_request():
     """
         Treat all incoming requests before-hand. 
-        If the user is not yet logged in, he/she will redirected towards the login page.
+        If the user is not yet logged in, he/she will be redirected towards the login page.
     """
     if(HTTPS):
         token = request.cookies.get('AUTH')
@@ -84,6 +85,7 @@ def before_request():
                                        msg='🔒 Enter your secret key to access the scanner:')
 
 # ################### ROUTES ####################
+
 
 @app.route('/login', methods=['POST', 'GET'])
 def login():
@@ -105,7 +107,7 @@ def login():
             # We store the HttpOnly token on the browser. A HttpOnly token
             # cannot be accessed by javascript for security purposes
             resp.set_cookie('AUTH', value=str(access_token), httponly=True,
-                            secure=True, max_age=datetime.timedelta(minutes=1))
+                            secure=True)
 
             # Store the new JWT value in the registered_tokens list
             registered_tokens.append(str(access_token))
@@ -114,6 +116,7 @@ def login():
             redirect(url_for('login'))
             return render_template('login.html',
                                    msg='🔒 Enter your secret key to access the scanner:')
+
 
 @app.route('/logout')
 def logout():
@@ -125,6 +128,7 @@ def logout():
     registered_tokens.remove(token)
     resp = make_response(redirect(url_for('root')))
     return resp
+
 
 @app.route('/')
 def root():
@@ -389,6 +393,7 @@ def update_discovery_group():
         return 'Error in updatating the discovery group', 500
     else:
         return 'OK', 200
+
 
 jwt = JWTManager(app)
 if __name__ == '__main__':

--- a/ui/server.py
+++ b/ui/server.py
@@ -67,6 +67,20 @@ def _get_rules():
 
     return rulesdict, cat
 
+registered_tokens = []
+
+@app.before_request
+def before_request():
+    """
+        Treat all incoming requests before-hand. 
+        If the user is not yet logged in, he/she will redirected towards the login page.
+    """
+    if(HTTPS):
+        token = request.cookies.get('AUTH')
+        if(token not in registered_tokens):
+            if(request.endpoint != 'login' and '/res/' not in request.path):
+                return render_template('login.html',
+                                       msg='🔒 Enter your secret key to access the scanner:')
 
 # ################### ROUTES ####################
 

--- a/ui/server.py
+++ b/ui/server.py
@@ -28,8 +28,8 @@ app.config['DEBUG'] = True  # Remove this line in production
 app.config['SECRET_KEY'] = os.getenv('SECRET_KEY')
 
 # HTTPS = True if both a certificate and private key exist, False otherwise.
-HTTPS = (os.getenv('SSL_certificate') !=
-         '' and os.getenv('SSL_private_key') != '')
+HTTPS = os.getenv('SSL_certificate') != '' and os.getenv(
+    'SSL_private_key') != ''
 
 if os.getenv('USE_PG') == 'True':
     app.logger.info('Use Postgres Client')
@@ -78,10 +78,10 @@ def before_request():
     Treat all incoming requests before-hand. 
     If the user is not yet logged in, he/she will be redirected towards the login page.
     """
-    if(HTTPS):
+    if HTTPS:
         token = request.cookies.get('AUTH')
-        if(token not in registered_tokens):
-            if(request.endpoint != 'login' and '/res/' not in request.path):
+        if token not in registered_tokens:
+            if request.endpoint != 'login' and '/res/' not in request.path:
                 return render_template('login.html',
                                        msg='🔒 Enter your secret key to access the scanner:')
 
@@ -91,12 +91,12 @@ def before_request():
 @app.route('/login', methods=['POST', 'GET'])
 def login():
     # If the HTTPS protocol is not in use, then the login feature will be disabled.
-    if(not HTTPS):
+    if not HTTPS:
         redirect(url_for('root'))
     else:
-        if(request.method == 'POST'):
+        if request.method == 'POST':
             auth_key = request.form['auth_key']
-            if(auth_key != os.getenv('AUTH_KEY')):
+            if auth_key != os.getenv('AUTH_KEY'):
                 redirect(url_for('login'))
                 return render_template('login.html',
                                        msg='❌ Wrong key, please try again:')

--- a/ui/server.py
+++ b/ui/server.py
@@ -106,7 +106,7 @@ def login():
             # cannot be accessed by javascript for security purposes
             resp.set_cookie('AUTH', value=str(access_token), httponly=True,
                             secure=True, max_age=datetime.timedelta(minutes=1))
-                            
+
             # Store the new JWT value in the registered_tokens list
             registered_tokens.append(str(access_token))
             return resp
@@ -114,6 +114,17 @@ def login():
             redirect(url_for('login'))
             return render_template('login.html',
                                    msg='🔒 Enter your secret key to access the scanner:')
+
+@app.route('/logout')
+def logout():
+    """
+    The user loses his access to the tool when his JWT no longer exists in the local
+    registered_tokens list.
+    """
+    token = request.cookies.get('AUTH')
+    registered_tokens.remove(token)
+    resp = make_response(redirect(url_for('root')))
+    return resp
 
 @app.route('/')
 def root():
@@ -379,6 +390,6 @@ def update_discovery_group():
     else:
         return 'OK', 200
 
-
+jwt = JWTManager(app)
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -29,7 +29,7 @@
         <img class="headerTitleIcon" src="/res/img/logo-CD.svg">
         <span class="headerTitleText">Credential Digger</span>
       </a>
-      <div class="headerLinkList">
+      <div class="headerLinkList" id="topRightButtons">
         <a class="headerItem headerLink" href="/">Repositories</a>
         <a class="headerItem headerLink" href="/rules">Rules</a>
       </div>

--- a/ui/templates/login.html
+++ b/ui/templates/login.html
@@ -1,0 +1,35 @@
+{% extends 'base.html' %}
+{% block content %}
+
+<head>
+    <style>
+        .center-div {
+            display: block;
+            text-align: center;
+            margin: 0 auto;
+            text-align: center;
+            border: 1px solid rgb(59, 155, 219);
+            width: max-content;
+            padding: 20px 20px;
+        }
+
+        .put-center {
+            margin: 0 auto;
+        }
+    </style>
+    <script>
+        window.onload = function () {
+            sessionStorage.setItem("logged_in", "False");
+        }
+    </script>
+</head>
+
+<div class="center-div">
+    <form class='put-center' action="/login" method="post">
+        <label>{{msg}}</label><br /><br />
+        <input type="password" id="auth_key" name="auth_key" />
+        <input style="margin-left: 10px;" class="btn primary-bg" id="submit_btn" type="submit" value="Connect" />
+    </form>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Targeted issue:
#94 
Builds upon:
#96 

### Feats
This PR introduces a new secure UI for accessing the tool. 
When the UI starts while HTTPS support is enabled, the UI will force the user to login in order to use the tool.  

### How to run
Nothing changes:  the users can just start the docker container without any changes, this will result in a login page asking them to insert an authentication key. They can use the generic password `admin` (please remember to change it).

### How to customize

- The users have to set up their custom password in`.env` by modifying the `AUTH_KEY` variable which is set to `admin` by default.
- The secret key (SECRET_KEY variable in the `.env` file) has to be generated again by the user using the command: `python -c 'import os; print(os.urandom(24).hex())'`. This SECRET_KEY will be used to securely sign the JWT (Json Web Token).

> #### ⚠️**NEVER REVEAL THE SECRET KEY NOR THE PASSWORD**

### Misc
A wiki page; detailing the process of customizing the login experience, will be written upon the merge of this PR.