### PR TITLE
[Fix] Fixed multiple pre-processing bugs

### DIFF
--- a/credentialdigger/models/snippet_model/snippet_model.py
+++ b/credentialdigger/models/snippet_model/snippet_model.py
@@ -76,7 +76,7 @@ class SnippetModel(BaseModel):
             # No need to run the model: we assume this is a false positive
             # since either the snippet is empty or there is just one word
             return True
-        
+
         # Classify as a 'Leak' if this is a private key.
         if self._check_private_key(data):
             return False
@@ -108,8 +108,8 @@ class SnippetModel(BaseModel):
         We define as strings any sequence of characters included in `"` or `'`
         and as words any sequence of alphanumeric characters.
 
-        Finally, convert words (not strings) from snake_case (i.e., words 
-        separated by underscores, like in Python convention) to CamelCase 
+        Finally, convert words (not strings) from snake_case (i.e., words
+        separated by underscores, like in Python convention) to CamelCase
         (i.e., Java convention).
 
         Parameters
@@ -147,9 +147,9 @@ class SnippetModel(BaseModel):
         ]
         """
         # Extract all the words in a snippet
-        words = re.findall("(?<=').*?(?=')|(?<=\").*?(?=\")|[\w\d]+", raw_data)
+        words = re.findall(r'(?<=\').*?(?=\')|(?<=").*?(?=")|[\w\d]+', raw_data)
         # Extract only the words that are between " or ', we refer to them strings
-        strings = re.findall(r"(?<=').*?(?=')|(?<=\").*?(?=\")", raw_data)
+        strings = re.findall(r'(?<=\').*?(?=\')|(?<=").*?(?=")', raw_data)
 
         camel_case_words = []
         for w in words:
@@ -217,7 +217,6 @@ class SnippetModel(BaseModel):
             r'^((\s*|\ *)\@\@.*\@\@(\s*|\ *)|(\s*|\ *)\+(\s*|\ *)|(\s*|\ *)\-(\s*|\ *)|(\s*|\ *))',
             "",
             snippet).strip()
-
 
     def _check_private_key(self, snippet):
         """ Check if this snippet is a private key

--- a/credentialdigger/models/snippet_model/snippet_model.py
+++ b/credentialdigger/models/snippet_model/snippet_model.py
@@ -133,17 +133,19 @@ class SnippetModel(BaseModel):
 
         >>> raw_data = '"password": "#####", "!@AAA12")'
         >>> print(self._pre_process(raw_data))
-        ['password', 'AAA12']
+        ['password','"#####', '!@AAA12']
         """
-        # r"((?<=').*?(?=')|(?<=\").*?(?=\")|[a-zA-Z0-9\._@-]+)"
-        # Match words and strings
-        # In strings, match the content starting from the first character
-        # e.g., "****" -> None
-        #       "$AAA123!!" -> AAA123!!
-        pattern = re.compile(
-            r"((?<=')\w\d.*?(?=')|(?<=\")\w\d.*?(?=\")|[\w\d]+)")
-        words = re.findall(pattern, raw_data)
-        return list(map(string_utils.snake_case_to_camel, words))
+        words = re.findall("(?<=').*?(?=')|(?<=\").*?(?=\")|[\w\d]+", raw_data)
+        strings = re.findall(r"(?<=').*?(?=')|(?<=\").*?(?=\")", raw_data)
+
+        camel_case_words = []
+        for w in words:
+            if(w in strings):
+                camel_case_words.append(w)
+            else:
+                camel_case_words.append(string_utils.snake_case_to_camel(w))
+
+        return camel_case_words
 
     def _label_preprocess(self, words_list):
         """ Output the extracted word from the label of the model.

--- a/credentialdigger/models/snippet_model/snippet_model.py
+++ b/credentialdigger/models/snippet_model/snippet_model.py
@@ -101,7 +101,7 @@ class SnippetModel(BaseModel):
         Find words and strings in `raw_data` and extract them.
         We define as strings any sequence of characters included in `"` or `'`
         and as words any sequence of alphanumeric characters.
-
+        
         In particular, if a string does not contain characters, it is not
         matched. This is done in order to exclude patterns such as "###" or
         "***". In case the string has a mixed content, it is matched starting

--- a/credentialdigger/models/snippet_model/snippet_model.py
+++ b/credentialdigger/models/snippet_model/snippet_model.py
@@ -4,6 +4,7 @@ import fasttext
 import string_utils
 
 from ..base_model import BaseModel
+from difflib import SequenceMatcher
 
 EXTENSIONS = set(['py', 'rb', 'c', 'cpp', 'cs', 'js', 'php', 'h', 'java', 'pl',
                   'go'])

--- a/credentialdigger/models/snippet_model/snippet_model.py
+++ b/credentialdigger/models/snippet_model/snippet_model.py
@@ -210,7 +210,6 @@ class SnippetModel(BaseModel):
         for symbol in assignment_symbols:
             findings = re.findall(f'(.*){symbol}(.*)', snippet)
             if(len(findings) > 0):
-                #print(f'This is an assignment : {findings}')
                 return True
         return False
 

--- a/credentialdigger/models/snippet_model/snippet_model.py
+++ b/credentialdigger/models/snippet_model/snippet_model.py
@@ -141,7 +141,7 @@ class SnippetModel(BaseModel):
 
         >>> raw_data = '"password": "#####", "!@AAA12")'
         >>> print(self._pre_process(raw_data))
-        ['password','"#####', '!@AAA12']
+        ['password','"#####"', '!@AAA12']
 
         Manual execution
         --------

--- a/credentialdigger/models/snippet_model/snippet_model.py
+++ b/credentialdigger/models/snippet_model/snippet_model.py
@@ -135,13 +135,22 @@ class SnippetModel(BaseModel):
         >>> raw_data = '"password": "#####", "!@AAA12")'
         >>> print(self._pre_process(raw_data))
         ['password','"#####', '!@AAA12']
+
+        Manual execution
+        --------
+        >>> raw_data = 'pwd = "pwd_123";'
+        >>> print(self._pre_process(raw_data))
+        [
+            words = [pwd, pwd_123]
+            strings = [pwd_123] # Will not be converted into camel_case
+            camel_case_words = [Pwd, pwd_123]
+        ]
         """
         # Extract all the words in a snippet
         words = re.findall("(?<=').*?(?=')|(?<=\").*?(?=\")|[\w\d]+", raw_data)
         # Extract only the words that are between " or ', we refer to them strings
         strings = re.findall(r"(?<=').*?(?=')|(?<=\").*?(?=\")", raw_data)
 
-        
         camel_case_words = []
         for w in words:
             # If a word is a string, we do not make any changes to it
@@ -205,7 +214,7 @@ class SnippetModel(BaseModel):
         """ Remove junk from the beginning of a snippet.
         """
         return re.sub(
-            r"^((\s*|\ *)\@\@.*\@\@(\s*|\ *)|(\s*|\ *)\+(\s*|\ *)|(\s*|\ *)\-(\s*|\ *)|(\s*|\ *))",
+            r'^((\s*|\ *)\@\@.*\@\@(\s*|\ *)|(\s*|\ *)\+(\s*|\ *)|(\s*|\ *)\-(\s*|\ *)|(\s*|\ *))',
             "",
             snippet).strip()
 

--- a/credentialdigger/models/snippet_model/snippet_model.py
+++ b/credentialdigger/models/snippet_model/snippet_model.py
@@ -71,7 +71,7 @@ class SnippetModel(BaseModel):
         if(self._check_private_key(data)):
             return False
         if(not any(not c.isalnum() and c not in ' _.,?!/' for c in raw_data)):
-            # We ignore snippets that look like regular phrases with 
+            # We ignore snippets that look like regular phrases with
             # no assignment
             return True
 
@@ -102,7 +102,7 @@ class SnippetModel(BaseModel):
         Find words and strings in `raw_data` and extract them.
         We define as strings any sequence of characters included in `"` or `'`
         and as words any sequence of alphanumeric characters.
-        
+
         Finally, convert words (not strings) from snake_case (i.e., words 
         separated by underscores, like in Python convention) to CamelCase 
         (i.e., Java convention).
@@ -210,7 +210,7 @@ class SnippetModel(BaseModel):
                 #print(f'This is an assignment : {findings}')
                 return True
         return False
-    
+
     def _check_private_key(self, snippet):
         """ Check if this snippet is a private key
         """

--- a/credentialdigger/models/snippet_model/snippet_model.py
+++ b/credentialdigger/models/snippet_model/snippet_model.py
@@ -198,3 +198,14 @@ class SnippetModel(BaseModel):
             r"^((\s*|\ *)\@\@.*\@\@(\s*|\ *)|(\s*|\ *)\+(\s*|\ *)|(\s*|\ *)\-(\s*|\ *)|(\s*|\ *))",
             "",
             snippet).strip()
+
+    def _assignment_expression(self, snippet):
+        """ Check if the snippet is an assignment or not.
+        """
+        assignment_symbols = ['=', ':=', '<-', ':']
+        for symbol in assignment_symbols:
+            findings = re.findall(f'(.*){symbol}(.*)', snippet)
+            if(len(findings) > 0):
+                #print(f'This is an assignment : {findings}')
+                return True
+        return False

--- a/credentialdigger/models/snippet_model/snippet_model.py
+++ b/credentialdigger/models/snippet_model/snippet_model.py
@@ -76,9 +76,10 @@ class SnippetModel(BaseModel):
             # No need to run the model: we assume this is a false positive
             # since either the snippet is empty or there is just one word
             return True
-            
+
         # Extract the committed secret
         index_of_value = self._label_preprocess(data)
+        
         # Classify as a 'Leak' if this is a private key.
         if self._check_private_key(data):
             return False

--- a/credentialdigger/models/snippet_model/snippet_model.py
+++ b/credentialdigger/models/snippet_model/snippet_model.py
@@ -219,7 +219,7 @@ class SnippetModel(BaseModel):
 
     def _not_an_assignment(self, snippet):
         """We ignore snippets that look like regular phrases with no assignment hints.
-        
+
         Parameters
         ----------
         snippet: str
@@ -228,7 +228,7 @@ class SnippetModel(BaseModel):
         Returns
         -------
         boolean 
-            If the snippet contains any symbols that may lead to password assignment
+            True if the snippet contains any symbols that may lead to password assignment
 
         """
 

--- a/credentialdigger/models/snippet_model/snippet_model.py
+++ b/credentialdigger/models/snippet_model/snippet_model.py
@@ -83,7 +83,9 @@ class SnippetModel(BaseModel):
                 return True
             else:
                 data = self._pre_process(raw_data)
+
         input_text = data[-1]
+
         if(len(input_text) <= 3):
             # We ignore any password shorter than or equal to 3
             return True

--- a/credentialdigger/models/snippet_model/snippet_model.py
+++ b/credentialdigger/models/snippet_model/snippet_model.py
@@ -76,7 +76,9 @@ class SnippetModel(BaseModel):
             # No need to run the model: we assume this is a false positive
             # since either the snippet is empty or there is just one word
             return True
-
+            
+        # Extract the committed secret
+        index_of_value = self._label_preprocess(data)
         # Classify as a 'Leak' if this is a private key.
         if self._check_private_key(data):
             return False
@@ -86,8 +88,7 @@ class SnippetModel(BaseModel):
         if not any(not c.isalnum() and c not in ' _.,?!/' for c in raw_data):
             return True
 
-        input_text = data[-1]
-
+        input_text = data[index_of_value[1]]
         if len(input_text) <= 3:
             # We ignore any password shorter than or equal to 3
             return True

--- a/credentialdigger/models/snippet_model/snippet_model.py
+++ b/credentialdigger/models/snippet_model/snippet_model.py
@@ -145,8 +145,10 @@ class SnippetModel(BaseModel):
         ['password','"#####"', '!@AAA12']
         """
         # Extract all the words in a snippet
-        words = re.findall(r'(?<=\').*?(?=\')|(?<=").*?(?=")|[\w\d]+', raw_data)
-        # Extract only the words that are between " or ', we refer to them strings
+        words = re.findall(r'(?<=\').*?(?=\')|(?<=").*?(?=")|[\w\d]+',
+                           raw_data)
+        # Extract only the words that are between " or ', we refer to them
+        # as strings
         strings = re.findall(r'(?<=\').*?(?=\')|(?<=").*?(?=")', raw_data)
 
         camel_case_words = []

--- a/credentialdigger/models/snippet_model/snippet_model.py
+++ b/credentialdigger/models/snippet_model/snippet_model.py
@@ -209,3 +209,10 @@ class SnippetModel(BaseModel):
                 #print(f'This is an assignment : {findings}')
                 return True
         return False
+    
+    def _check_private_key(self, snippet):
+        """ Check if this snippet is a private key
+        """
+        base_private_key = ['BEGIN', 'PRIVATE', 'KEY']
+        # Return True if similarity ration >= 85%
+        return SequenceMatcher(None, base_private_key, snippet).ratio() >= 0.85

--- a/credentialdigger/models/snippet_model/snippet_model.py
+++ b/credentialdigger/models/snippet_model/snippet_model.py
@@ -102,14 +102,9 @@ class SnippetModel(BaseModel):
         We define as strings any sequence of characters included in `"` or `'`
         and as words any sequence of alphanumeric characters.
         
-        In particular, if a string does not contain characters, it is not
-        matched. This is done in order to exclude patterns such as "###" or
-        "***". In case the string has a mixed content, it is matched starting
-        from the first letter/number (e.g., "!@#QWE123" matches "QWE123").
-
-        Finally, convert words from snake_case (i.e., words separated by
-        underscores, like in Python convention) to CamelCase (i.e., Java
-        convention).
+        Finally, convert words (not strings) from snake_case (i.e., words 
+        separated by underscores, like in Python convention) to CamelCase 
+        (i.e., Java convention).
 
         Parameters
         ----------

--- a/credentialdigger/models/snippet_model/snippet_model.py
+++ b/credentialdigger/models/snippet_model/snippet_model.py
@@ -219,7 +219,9 @@ class SnippetModel(BaseModel):
 
     def _not_an_assignment(self, snippet):
         """We ignore snippets that look like regular phrases with no assignment hints.
-        Parameters:
+        
+        Parameters
+        ----------
         snippet: str
                  A snippet (as appears in its commit diff)
 

--- a/tests/functional_tests/test_scans_postgres.py
+++ b/tests/functional_tests/test_scans_postgres.py
@@ -46,7 +46,7 @@ class TestScansPostgres(unittest.TestCase):
                       "--models", "PathModel", "SnippetModel",
                       "--category", "password",
                       "--force", "--local", repo_path])
-        self.assertEqual(cm.exception.code, 4)
+        self.assertEqual(cm.exception.code, 2)
 
         shutil.rmtree(repo_path)
 

--- a/tests/functional_tests/test_scans_sqlite.py
+++ b/tests/functional_tests/test_scans_sqlite.py
@@ -38,7 +38,7 @@ class TestScansSqlite(unittest.TestCase):
                       "--models", "PathModel", "SnippetModel",
                       "--category", "password",
                       "--force", "--local", repo_path])
-        self.assertEqual(cm.exception.code, 4)
+        self.assertEqual(cm.exception.code, 2)
 
     def test_scan_wiki(self):
         with self.assertRaises(SystemExit) as cm:


### PR DESCRIPTION
#### This PR fixes multiple pre-processing issues. It also edits how we feed the input data into the classifier: now we only pass the passward/token to classify instead of a couple.

#### List of fixed bugs:
- BUG: the tool fails to extract the passwords correctly when they contain special characters
    - i.e : password = "hello!all."
        - we get : [password, hello, all]
    - correct: [password, hello!all.]
    [!] Fixed (regex)
 
- BUG: The tool ignores assignments between quotes
    - i.e 
            "Env": [
                "NPM_PASSWORD=123"
            ]
        the tool ignores this because it thinks that it is a 1 word password (because it is contained within two commas)
    - correct result: this should have been considered as an assignment and treated accordingly => [NPM_PASSWORD, 123]
    [!] Fixed (regex)
 
- BUG: In some cases, the tool removes the special characters before extracting the password
    - i.e MSSQL_PWD=Db3xpr3ss10n#F => [MSSQL_PWD, Db3xpr3ss10n, F]
    - correct res: [MSSQL_PWD, Db3xpr3ss10n#F]
    [!] Fixed using regex + strings manipulation techniques

- BUG: the passwords contained between commas get converted into CameCase format
	- i.e pwd = "hello_world" => [Pwd, HelloWorld]
	- [!] Fixed by excluding the words extracted from commas from the converting algorithms.

- BUG: we try to extract private keys and classify their values.
    - Instead of extracting the value of the key, we now that private keys have a certain format to them so we classify them as Leaks directly without feeding them to the classifier.

> 