### PR TITLE
Fix/show on GitHub + requirments.txt adaptation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,9 @@ pyyaml
 requests
 scikit-learn
 srsly
-tensorflow==2.4.1
-tensorflow-text==2.4.1
+tensorflow==2.5; python_version > '3.7'
+tensorflow==2.4.1; python_version < '3.8'
+tensorflow-text==2.5; python_version > '3.7'
+tensorflow-text==2.4.1; python_version < '3.8'
 tf-models-official
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fasttext
 GitPython
-hyperscan==0.1.5
+hyperscan==0.2.0; sys.platform == 'darwin'
+hyperscan==0.1.5; sys.platform == 'linux'
 leven
 nltk
 numpy
@@ -13,9 +14,9 @@ pyyaml
 requests
 scikit-learn
 srsly
-tensorflow==2.5; python_version > '3.7'
-tensorflow==2.4.1; python_version < '3.8'
-tensorflow-text==2.5; python_version > '3.7'
-tensorflow-text==2.4.1; python_version < '3.8'
+tensorflow==2.5.0; python_version >= "3.8"
+tensorflow==2.4.1; python_version < "3.8"
+tensorflow-text==2.5.0; python_version >= "3.8"
+tensorflow-text==2.4.1; python_version < "3.8"
 tf-models-official
 tqdm

--- a/ui/res/js/discoveries.js
+++ b/ui/res/js/discoveries.js
@@ -106,7 +106,7 @@ function initDiscoveriesDataTable() {
         orderable: false
       }
     ],
-    searchCols: [null, null, null, {search: 'new'}, null, null, null],
+    searchCols: [null, null, null, { search: 'new' }, null, null, null],
     ajax: { // AJAX source info
       url: "/get_discoveries",
       data: {
@@ -121,19 +121,19 @@ function initDiscoveriesDataTable() {
           <table>
             <thead>
               <tr>
-                ${filename ? '': '<th>File</th>'}
+                ${filename ? '' : '<th>File</th>'}
                 <th class="hash">Commit hash</th><th class="dt-center">Line number</th>
                 <th>Actions</th>
               </tr>
             </thead>
             <tbody>
-              ${item.occurrences.slice(0,10).map(i => `
+              ${item.occurrences.slice(0, 10).map(i => `
                 <tr>
                   ${filename ? "" : `<td class="filename"><span>${i.file_name}</span></td>`}
                   <td class="hash">${i.commit_id}</td>
                   <td class="dt-center">${i.line_number}</td>
                   <td>
-                    <a class="btn btn-light grey-color" target="_blank" href="${repoUrl}/blob/${i.commit_id}/${i.file_name}#L${i.line_number}">
+                    <a class="btn btn-light grey-color" target="_blank" href="${repoUrl.endsWith(".git") ? repoUrl.slice(0, -4) : repoUrl}/blob/${i.commit_id}/${i.file_name}#L${i.line_number}">
                       <span class="icon icon-github"></span>
                       <span class="btn-text">Show on GitHub</span>
                     </a>
@@ -160,10 +160,10 @@ function initDiscoveriesDataTable() {
     initComplete: function () {
       var column = this.api().columns(3);
       var select = $('<select><option value=""></option></select>')
-        .on( 'change', function () {
+        .on('change', function () {
           var val = $.fn.dataTable.util.escapeRegex($(this).val());
           column.search(val).draw();
-        } );
+        });
 
       select.append(`
         <option value="all">all</option>
@@ -180,7 +180,7 @@ function initDiscoveriesDataTable() {
           <div id="select-filter-container"></div>
         </div>`);
       $('#select-filter-container').append(select);
-  }
+    }
   });
 }
 
@@ -200,7 +200,7 @@ function initUpdateDiscoveries() {
       filename = document.querySelector("#file-name").innerText;
       snippet = this.closest('tr')?.querySelector('.snippet')?.innerHTML;
     }
-    
+
     $.ajax({
       url: 'update_discovery_group',
       method: 'POST',
@@ -210,7 +210,7 @@ function initUpdateDiscoveries() {
         ...filename && { file: filename },
         ...snippet && { snippet: decodeHTML(snippet) }
       },
-      beforeSend: function() {
+      beforeSend: function () {
         datatable.processing(true);
       },
       success: function () {
@@ -225,19 +225,19 @@ function initUpdateDiscoveries() {
  */
 function initUpdateScanning() {
   // Get status only if scanning when loading the page
-  if(!document.querySelector('#newScan.disabled')) return;
+  if (!document.querySelector('#newScan.disabled')) return;
   scanInterval = setInterval(getScan, POLLING_INTERVAL);
 }
 
 let scanInterval = null;
-const getScan = function() {
+const getScan = function () {
   const repoUrl = document.querySelector('#repo-url').innerText;
   $.ajax({
     url: '/get_scan_status',
-    data: {url: repoUrl},
-    success: function(json) {
+    data: { url: repoUrl },
+    success: function (json) {
       const btn = document.querySelector('#newScan');
-      if(json.scanning) {
+      if (json.scanning) {
         btn.disabled = true;
         btn.classList.add('disabled');
         btn.classList.add('warning-bg');
@@ -252,7 +252,7 @@ const getScan = function() {
         btn.classList.add('primary-bg');
         btn.innerHTML = `
           <span class="icon icon-refresh"></span><span>Rescan</span>`;
-        if($('#discoveries-table, #files-table')) $('.dataTable').DataTable().ajax.reload();
+        if ($('#discoveries-table, #files-table')) $('.dataTable').DataTable().ajax.reload();
       }
     }
   })


### PR DESCRIPTION
### Fix Show on Github button + update requirments.txt
- It is now possible to "Show on Github" for repos that with urls that end with `.git` 
- Updated the requirments.txt file so it install the adapted version of tensorflow and its sub-libraries according to the installed version of Python.
