### PR TITLE
adjust dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fasttext
 GitPython
-hyperscan==0.1.5
+hyperscan==0.2.0; sys.platform == "dawin"
+hyperscan==0.1.5; sys.platform == "linux"
 leven
 nltk
 numpy
@@ -13,7 +14,9 @@ pyyaml
 requests
 scikit-learn
 srsly
-tensorflow==2.4.1
-tensorflow-text==2.4.1
+tensorflow==2.5.0; python_version > "3.7"
+tensorflow==2.4.1; python_version < "3.8"
+tensorflow-text==2.5.0; python_version > "3.7"
+tensorflow-text==2.4.1; python_version < "3.8"
 tf-models-official
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setuptools.setup(
         'Programming Language :: Python :: 3',
         'Operating System :: OS Independent',
     ],
-    python_requires='>3.5, <3.9',
+    python_requires='>3.5, <=3.9',
 )


### PR DESCRIPTION
Different platforms (linux vs darwin) and python versions (notably, v3.6 and 3.7 vs 3.8 and 3.9) need different versions for some packages. Try to automatically manage this