### PR TITLE
[FIX] Fixed discoveries appending (duplicating?) when rescanning a repo

### DIFF
--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -874,8 +874,7 @@ class Client(Interface):
             from_timestamp = 0
 
         # Call scanner
-        if 'since_timestamp' in scanner_kwargs:
-            scanner_kwargs['since_timestamp'] = from_timestamp
+        scanner_kwargs['since_timestamp'] = from_timestamp
         try:
             logger.debug('Start scan')
             new_discoveries = scanner.scan(repo_url,


### PR DESCRIPTION
Removed never-satisfied condition, now we can make sure not append the **same** discoveries into the database to avoid **duplications.**