### PR TITLE
[Feat] Trim the repo url before starting a scan

### DIFF
--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -777,11 +777,12 @@ class Client(Interface):
         if local_repo:
             repo_url = os.path.abspath(repo_url)
         else:
+            # Trim the tail of the repo's url by removing '/' and '.git'
             if repo_url.endswith('/'):
                 repo_url = repo_url[:-1]
             if repo_url.endswith('.git'):
                 repo_url = repo_url[:-4]
-                
+
         rules = self._get_scan_rules(category, exclude)
         scanner = GitScanner(rules)
 

--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -776,7 +776,12 @@ class Client(Interface):
         """
         if local_repo:
             repo_url = os.path.abspath(repo_url)
-
+        else:
+            if repo_url.endswith('/'):
+                repo_url = repo_url[:-1]
+            if repo_url.endswith('.git'):
+                repo_url = repo_url[:-4]
+                
         rules = self._get_scan_rules(category, exclude)
         scanner = GitScanner(rules)
 

--- a/ui/res/js/discoveries.js
+++ b/ui/res/js/discoveries.js
@@ -139,10 +139,10 @@ function initDiscoveriesDataTable() {
                   <td class="hash">${i.commit_id}</td>
                   <td class="dt-center">${i.line_number}</td>
                   <td>
-                    <a class="btn btn-light grey-color" target="_blank" href="${repoUrl.endsWith(".git") ? repoUrl.slice(0, -4) : repoUrl}/blob/${i.commit_id}/${i.file_name}#L${i.line_number}">
-                      <span class="icon icon-github"></span>
-                      <span class="btn-text">Show on GitHub</span>
-                    </a>
+                  <a class="btn btn-light grey-color" target="_blank" href="${repoUrl}/blob/${i.commit_id}/${i.file_name}#L${i.line_number}">
+                  <span class="icon icon-github"></span>
+                  <span class="btn-text">Show on GitHub</span>
+                </a>
                   </td>
                 </tr>
               `).join('\n')}


### PR DESCRIPTION
We do not have test the ending of the repo url for every discovery line, because we now have universal url format that cannot finish either with a slash '/' nor  '.git'.
_PS: this is only for remote repos, because local repos may contain '.git' by the end in some case._

We remove the JavaScript ternary operator when using the "Show on Github" Feature.
