### PR TITLE
[FIX] Safely pass the timestamp argument to scan functions

### DIFF
--- a/credentialdigger/scanners/file_scanner.py
+++ b/credentialdigger/scanners/file_scanner.py
@@ -50,7 +50,8 @@ class FileScanner(BaseScanner):
                              elements=len(patterns),
                              flags=flags)
 
-    def scan(self, scan_path, max_depth=-1, ignore_list=[], debug=False):
+    def scan(self, scan_path, max_depth=-1, ignore_list=[], debug=False, 
+             **kwargs):
         """ Scan a directory.
 
         Parameters
@@ -67,6 +68,8 @@ class FileScanner(BaseScanner):
             per the fnmatch package.
         debug: bool, optional
             If True, visualize debug information during the scan
+        kwargs: kwargs
+            Keyword arguments to be passed to the scanner
 
         Returns
         -------

--- a/credentialdigger/scanners/file_scanner.py
+++ b/credentialdigger/scanners/file_scanner.py
@@ -50,7 +50,7 @@ class FileScanner(BaseScanner):
                              elements=len(patterns),
                              flags=flags)
 
-    def scan(self, scan_path, max_depth=-1, ignore_list=[], debug=False, 
+    def scan(self, scan_path, max_depth=-1, ignore_list=[], debug=False,
              **kwargs):
         """ Scan a directory.
 

--- a/credentialdigger/scanners/git_file_scanner.py
+++ b/credentialdigger/scanners/git_file_scanner.py
@@ -73,7 +73,7 @@ class GitFileScanner(GitScanner, FileScanner):
             If True, visualize debug information during the scan
         kwargs: kwargs
             Keyword arguments to be passed to the scanner
-  
+
         Returns
         -------
         list

--- a/credentialdigger/scanners/git_file_scanner.py
+++ b/credentialdigger/scanners/git_file_scanner.py
@@ -73,7 +73,7 @@ class GitFileScanner(GitScanner, FileScanner):
             If True, visualize debug information during the scan
         kwargs: kwargs
             Keyword arguments to be passed to the scanner
-            
+  
         Returns
         -------
         list

--- a/credentialdigger/scanners/git_file_scanner.py
+++ b/credentialdigger/scanners/git_file_scanner.py
@@ -49,7 +49,7 @@ class GitFileScanner(GitScanner, FileScanner):
                              flags=flags)
 
     def scan(self, repo_url, branch_or_commit, max_depth=-1, ignore_list=[],
-             git_token=None, debug=False):
+             git_token=None, debug=False, **kwargs):
         """ Scan a repository.
 
         Parameters
@@ -71,7 +71,9 @@ class GitFileScanner(GitScanner, FileScanner):
             Git personal access token to authenticate to the git server
         debug: bool, optional
             If True, visualize debug information during the scan
-
+        kwargs: kwargs
+            Keyword arguments to be passed to the scanner
+            
         Returns
         -------
         list


### PR DESCRIPTION
Upon the merge of this PR, all the scanning functions will be able to avoid appending the same discoveries to the database (avoiding duplications).