### PR TITLE
deprecate excluded rules from scans

### DIFF
--- a/credentialdigger/cli/cli.py
+++ b/credentialdigger/cli/cli.py
@@ -48,9 +48,6 @@ def main(sys_argv):
         help='A list of models for the ML false positives detection.\nCannot \
             accept empty lists.')
     parser_scan_base.add_argument(
-        '--exclude', default=None, nargs='+',
-        help='A list of rules to exclude')
-    parser_scan_base.add_argument(
         '--debug', action='store_true',
         help='Flag used to decide whether to visualize the progressbars \
             during the scan (e.g., during the insertion of the detections in \

--- a/credentialdigger/cli/scan.py
+++ b/credentialdigger/cli/scan.py
@@ -8,8 +8,7 @@ database.
 
 usage: credentialdigger scan [-h] [--dotenv DOTENV] [--sqlite SQLITE]
                              [--category CATEGORY]
-                             [--models MODELS [MODELS ...]]
-                             [--exclude EXCLUDE [EXCLUDE ...]] [--debug]
+                             [--models MODELS [MODELS ...]] [--debug]
                              [--git_token GIT_TOKEN] [--local] [--force]
                              [--generate_snippet_extractor]
                              [--similarity]
@@ -32,8 +31,6 @@ optional arguments:
   --models MODELS [MODELS ...]
                         A list of models for the ML false positives detection.
                         Cannot accept empty lists.
-  --exclude EXCLUDE [EXCLUDE ...]
-                        A list of rules to exclude
   --debug               Flag used to decide whether to visualize the
                         progressbars during the scan (e.g., during the
                         insertion of the detections in the db)
@@ -118,7 +115,6 @@ def run(client, args):
         repo_url=args.repo_url,
         category=args.category,
         models=args.models,
-        exclude=args.exclude,
         force=args.force,
         debug=args.debug,
         generate_snippet_extractor=args.generate_snippet_extractor,

--- a/credentialdigger/cli/scan_path.py
+++ b/credentialdigger/cli/scan_path.py
@@ -8,8 +8,7 @@ database.
 
 usage: credentialdigger scan_path [-h] [--dotenv DOTENV] [--sqlite SQLITE]
                                   [--category CATEGORY]
-                                  [--models MODELS [MODELS ...]]
-                                  [--exclude EXCLUDE [EXCLUDE ...]] [--debug]
+                                  [--models MODELS [MODELS ...]] [--debug]
                                   [--force] [--generate_snippet_extractor]
                                   [--similarity]
                                   [--max_depth MAX_DEPTH]
@@ -31,8 +30,6 @@ optional arguments:
   --models MODELS [MODELS ...]
                         A list of models for the ML false positives detection.
                         Cannot accept empty lists.
-  --exclude EXCLUDE [EXCLUDE ...]
-                        A list of rules to exclude
   --debug               Flag used to decide whether to visualize the
                         progressbars during the scan (e.g., during the
                         insertion of the detections in the db)
@@ -113,7 +110,6 @@ def run(client, args):
         scan_path=args.scan_path,
         category=args.category,
         models=args.models,
-        exclude=args.exclude,
         force=args.force,
         debug=args.debug,
         generate_snippet_extractor=args.generate_snippet_extractor,

--- a/credentialdigger/cli/scan_snapshot.py
+++ b/credentialdigger/cli/scan_snapshot.py
@@ -11,7 +11,6 @@ usage: credentialdigger scan_snapshot [-h] [--dotenv DOTENV] [--sqlite SQLITE]
                                       [--snapshot BRANCH_NAME_OR_COMMIT_ID]
                                       [--category CATEGORY]
                                       [--models MODELS [MODELS ...]]
-                                      [--exclude EXCLUDE [EXCLUDE ...]]
                                       [--force] [--debug]
                                       [--git_token GIT_TOKEN]
                                       [--generate_snippet_extractor]
@@ -36,8 +35,6 @@ optional arguments:
   --models MODELS [MODELS ...]
                         A list of models for the ML false positives detection.
                         Cannot accept empty lists.
-  --exclude EXCLUDE [EXCLUDE ...]
-                        A list of rules to exclude
   --force               Force a complete re-scan of the repository, in case it
                         has already been scanned previously
   --debug               Flag used to decide whether to visualize the
@@ -129,7 +126,6 @@ def run(client, args):
         branch_or_commit=args.snapshot,
         category=args.category,
         models=args.models,
-        exclude=args.exclude,
         force=args.force,
         debug=args.debug,
         generate_snippet_extractor=args.generate_snippet_extractor,

--- a/credentialdigger/cli/scan_user.py
+++ b/credentialdigger/cli/scan_user.py
@@ -8,8 +8,7 @@ database.
 
 usage: credentialdigger scan_user [-h] [--dotenv DOTENV] [--sqlite SQLITE]
                                   [--category CATEGORY]
-                                  [--models MODELS [MODELS ...]]
-                                  [--exclude EXCLUDE [EXCLUDE ...]] [--debug]
+                                  [--models MODELS [MODELS ...]] [--debug]
                                   [--git_token GIT_TOKEN]
                                   [--generate_snippet_extractor] [--forks]
                                   [--similarity]
@@ -32,8 +31,6 @@ optional arguments:
   --models MODELS [MODELS ...]
                         A list of models for the ML false positives detection.
                         Cannot accept empty lists.
-  --exclude EXCLUDE [EXCLUDE ...]
-                        A list of rules to exclude
   --debug               Flag used to decide whether to visualize the
                         progressbars during the scan (e.g., during the
                         insertion of the detections in the db)
@@ -107,7 +104,6 @@ def run(client, args):
         username=args.username,
         category=args.category,
         models=args.models,
-        exclude=args.exclude,
         debug=args.debug,
         generate_snippet_extractor=args.generate_snippet_extractor,
         similarity=args.similarity,

--- a/credentialdigger/cli/scan_wiki.py
+++ b/credentialdigger/cli/scan_wiki.py
@@ -1,5 +1,5 @@
 """
-The 'scan_wiki' module can be used to scan the wiki of a git repository on the 
+The 'scan_wiki' module can be used to scan the wiki of a git repository on the
 fly from the terminal. It supports both the Sqlite and Postgres clients.
 
 NOTE: Postgres is used by default. Please make sure that the environment
@@ -9,7 +9,7 @@ database.
 usage: credentialdigger scan_wiki [-h] [--dotenv DOTENV] [--sqlite SQLITE]
                                   [--category CATEGORY]
                                   [--models MODELS [MODELS ...]]
-                                  [--exclude EXCLUDE [EXCLUDE ...]] [--debug]
+                                  [--debug]
                                   [--git_token GIT_TOKEN]
                                   repo_url
 
@@ -29,8 +29,6 @@ optional arguments:
   --models MODELS [MODELS ...]
                         A list of models for the ML false positives detection.
                         Cannot accept empty lists.
-  --exclude EXCLUDE [EXCLUDE ...]
-                        A list of rules to exclude
   --debug               Flag used to decide whether to visualize the
                         progressbars during the scan (e.g., during the
                         insertion of the detections in the db)
@@ -86,7 +84,6 @@ def run(client, args):
         repo_url=args.repo_url,
         category=args.category,
         models=args.models,
-        exclude=args.exclude,
         debug=args.debug,
         git_token=args.git_token)
 

--- a/tests/unit_tests/test_scans.py
+++ b/tests/unit_tests/test_scans.py
@@ -64,24 +64,30 @@ class TestScans(unittest.TestCase):
 
         self.assertTrue(len(new_discoveries) == 0)
 
-    def test_get_scan_rules_no_exclude(self):
-        """ All rules shoould be returned if no `exclude` argument is specified
-        """
+    def test_get_scan_rules(self):
+        """ All rules shoould be returned """
         self.client.get_rules.return_value = [{"id": 1}, {"id": 2}]
         rules = self.client._get_scan_rules()
         self.assertTrue(len(rules) == 2)
 
-    def test_get_scan_rules_exclude(self):
-        """ `exclude` parameter should correctly filter out rules """
-        self.client.get_rules.return_value = [{"id": 1}, {"id": 2}]
-        rules = self.client._get_scan_rules(exclude=[2])
-        self.assertTrue(len(rules) == 1 and rules[0]["id"] == 1)
-
-    def test_get_scan_rules_exclude_all(self):
+    def test_get_scan_rules_empty_rules_result(self):
         """ A resulting empty ruleset should raise an error """
-        self.client.get_rules.return_value = [{"id": 1}, {"id": 2}]
+        self.client.get_rules.return_value = []
         with self.assertRaises(ValueError):
-            self.client._get_scan_rules(exclude=[1, 2])
+            self.client._get_scan_rules()
+
+# Deprecated with v4.0, with `exclude` deprecated from the APIs of the scan
+#     def test_get_scan_rules_exclude(self):
+#         """ `exclude` parameter should correctly filter out rules """
+#         self.client.get_rules.return_value = [{"id": 1}, {"id": 2}]
+#         rules = self.client._get_scan_rules(exclude=[2])
+#         self.assertTrue(len(rules) == 1 and rules[0]["id"] == 1)
+#
+#     def test_get_scan_rules_exclude_all(self):
+#         """ A resulting empty ruleset should raise an error """
+#         self.client.get_rules.return_value = [{"id": 1}, {"id": 2}]
+#         with self.assertRaises(ValueError):
+#             self.client._get_scan_rules(exclude=[1, 2])
 
     @patch('credentialdigger.scanners.git_scanner.GitScanner')
     def test_scan_valid(self, mock_scanner):


### PR DESCRIPTION
Deprecate `exclude` parameter from all the `scan` functions