### PR TITLE
[Fix] Show on GitHub discoveries coming from scanned snapshots

### DIFF
--- a/credentialdigger/scanners/file_scanner.py
+++ b/credentialdigger/scanners/file_scanner.py
@@ -124,7 +124,7 @@ class FileScanner(BaseScanner):
         # NOTE: this may become inefficient when the discoveries are many.
         return all_discoveries
 
-    def scan_file(self, project_root, relative_path):
+    def scan_file(self, project_root, relative_path, **kwargs):
         """ Scan a single file for discoveries.
 
         Parameters
@@ -154,6 +154,9 @@ class FileScanner(BaseScanner):
                         match_event_handler=rh.handle_results,
                         context=[row.strip(), relative_path, '', line_number])
                     if rh.result:
+                        if 'branch_or_commit' in kwargs:
+                            rh.result.update(
+                                {'commit_id': kwargs['branch_or_commit']})
                         discoveries.append(rh.result)
                     line_number += 1
         except UnicodeDecodeError:

--- a/credentialdigger/scanners/file_scanner.py
+++ b/credentialdigger/scanners/file_scanner.py
@@ -133,6 +133,8 @@ class FileScanner(BaseScanner):
             Root path of the scanned project
         relative_path: str
             Path of the file, relative to `project_root`
+        kwargs: kwargs
+            Keyword arguments to be passed to the scanner
 
         Returns
         -------

--- a/credentialdigger/scanners/git_file_scanner.py
+++ b/credentialdigger/scanners/git_file_scanner.py
@@ -133,6 +133,7 @@ class GitFileScanner(GitScanner, FileScanner):
         logger.debug(f'Checkout {branch_or_commit}')
         repo.git.checkout(branch_or_commit)
 
+        scan_kwargs = {'branch_or_commit': branch_or_commit}
         all_discoveries = []
 
         project_root = repo.working_tree_dir
@@ -149,7 +150,8 @@ class GitFileScanner(GitScanner, FileScanner):
             for file_name in files:
                 rel_file_path = os.path.join(rel_dir_root, file_name)
                 file_discoveries = self.scan_file(
-                    project_root=project_root, relative_path=rel_file_path)
+                    project_root=project_root, relative_path=rel_file_path,
+                    **scan_kwargs)
                 all_discoveries.extend(file_discoveries)
 
         return all_discoveries


### PR DESCRIPTION
This PR targets this issue: https://github.com/SAP/credential-digger/issues/157

It is now possible to "show on github" discoveries that have been found in scanned snapshots.