### PR TITLE
[File view: Fix] Fix infinite loop when viewing discoveries by file.

### DIFF
--- a/ui/res/js/discoveries.js
+++ b/ui/res/js/discoveries.js
@@ -145,10 +145,10 @@ function initDiscoveriesDataTable() {
           ...(filename && { file: filename }),
         },
         dataSrc: function (json) {
-          postfix = " Leaks";
+          postfix = " leaks";
           switch (json.stateFilter) {
             case "false_positive":
-              postfix = " False positives";
+              postfix = " false positives";
               break;
             case "addressing":
               postfix = " addressing";

--- a/ui/res/js/discoveries.js
+++ b/ui/res/js/discoveries.js
@@ -158,23 +158,25 @@ function initDiscoveriesDataTable() {
             default:
               break;
           }
-          if (json.stateFilter != null) {
-            document.querySelector("#shownDiscoveriesCounter").innerHTML =
-              `<b><u>` + json.recordsTotal + postfix + `</u></b>`;
-            document.querySelector("#shownDiscoveriesCounter").title =
-              json.uniqueRecords + " Unique snippets";
-            document.querySelector(
-              "#totalDiscoveriesCounterWithBrackets"
-            ).style.display = "";
-            document.querySelector("#totalDiscoveriesCounter").style.display =
-              "none";
-          } else {
-            document.querySelector("#shownDiscoveriesCounter").innerHTML = "";
-            document.querySelector(
-              "#totalDiscoveriesCounterWithBrackets"
-            ).style.display = "none";
-            document.querySelector("#totalDiscoveriesCounter").style.display =
-              "";
+          if (document.querySelector("#shownDiscoveriesCounter") !== null) {
+            if (json.stateFilter != null) {
+              document.querySelector("#shownDiscoveriesCounter").innerHTML =
+                `<b><u>` + json.recordsTotal + postfix + `</u></b>`;
+              document.querySelector("#shownDiscoveriesCounter").title =
+                json.uniqueRecords + " Unique snippets";
+              document.querySelector(
+                "#totalDiscoveriesCounterWithBrackets"
+              ).style.display = "";
+              document.querySelector("#totalDiscoveriesCounter").style.display =
+                "none";
+            } else {
+              document.querySelector("#shownDiscoveriesCounter").innerHTML = "";
+              document.querySelector(
+                "#totalDiscoveriesCounterWithBrackets"
+              ).style.display = "none";
+              document.querySelector("#totalDiscoveriesCounter").style.display =
+                "";
+            }
           }
           return json.data.map((item) => {
             // Map json data before sending it to datatable


### PR DESCRIPTION
The page enters an infinite loop when viewing discoveries from a single file view.

We now check the existence of the HTML elements, if they are **null**, we abort the operation.