### PR TITLE
[Fix] Fixed file view for the display of total number of discoveries

### DIFF
--- a/ui/res/js/discoveries.js
+++ b/ui/res/js/discoveries.js
@@ -158,26 +158,26 @@ function initDiscoveriesDataTable() {
             default:
               break;
           }
-          if (document.querySelector("#shownDiscoveriesCounter") !== null) {
-            if (json.stateFilter != null) {
-              document.querySelector("#shownDiscoveriesCounter").innerHTML =
-                `<b><u>` + json.recordsTotal + postfix + `</u></b>`;
-              document.querySelector("#shownDiscoveriesCounter").title =
-                json.uniqueRecords + " Unique snippets";
-              document.querySelector(
-                "#totalDiscoveriesCounterWithBrackets"
-              ).style.display = "";
-              document.querySelector("#totalDiscoveriesCounter").style.display =
-                "none";
-            } else {
-              document.querySelector("#shownDiscoveriesCounter").innerHTML = "";
-              document.querySelector(
-                "#totalDiscoveriesCounterWithBrackets"
-              ).style.display = "none";
-              document.querySelector("#totalDiscoveriesCounter").style.display =
-                "";
-            }
+          
+          if (json.stateFilter != null) {
+            document.querySelector("#shownDiscoveriesCounter").innerHTML =
+              `<b><u>` + json.recordsTotal + postfix + `</u></b>`;
+            document.querySelector("#shownDiscoveriesCounter").title =
+              json.uniqueRecords + " Unique snippets";
+            document.querySelector(
+              "#totalDiscoveriesCounterWithBrackets"
+            ).style.display = "";
+            document.querySelector("#totalDiscoveriesCounter").style.display =
+              "none";
+          } else {
+            document.querySelector("#shownDiscoveriesCounter").innerHTML = "";
+            document.querySelector(
+              "#totalDiscoveriesCounterWithBrackets"
+            ).style.display = "none";
+            document.querySelector("#totalDiscoveriesCounter").style.display =
+              "";
           }
+
           return json.data.map((item) => {
             // Map json data before sending it to datatable
             const details = `

--- a/ui/res/js/discoveries.js
+++ b/ui/res/js/discoveries.js
@@ -21,7 +21,7 @@ function initFilesDataTable() {
     ...defaultTableSettings,
 
     pageLength: localStorage.hasOwnProperty("sharedPageLength")
-      ? localStorage.getItem("sharedPageLength")
+      ? parseInt(localStorage.getItem("sharedPageLength"))
       : 10,
     order: [[1, "desc"]], // Set default column sorting
     columns: [
@@ -99,7 +99,7 @@ function initDiscoveriesDataTable() {
     {
       ...defaultTableSettings,
       pageLength: localStorage.hasOwnProperty("sharedPageLength")
-        ? localStorage.getItem("sharedPageLength")
+        ? parseInt(localStorage.getItem("sharedPageLength"))
         : 10,
       serverSide: true,
       order: [[3, "asc"]], // Set default column sorting
@@ -158,7 +158,7 @@ function initDiscoveriesDataTable() {
             default:
               break;
           }
-          
+
           if (json.stateFilter != null) {
             document.querySelector("#shownDiscoveriesCounter").innerHTML =
               `<b><u>` + json.recordsTotal + postfix + `</u></b>`;

--- a/ui/res/js/repos.js
+++ b/ui/res/js/repos.js
@@ -21,7 +21,7 @@ function initReposDataTable() {
     {
       ...defaultTableSettings,
       pageLength: localStorage.hasOwnProperty("sharedPageLength")
-        ? localStorage.getItem("sharedPageLength")
+        ? parseInt(localStorage.getItem("sharedPageLength"))
         : 10,
       processing: false,
       order: [

--- a/ui/server.py
+++ b/ui/server.py
@@ -381,8 +381,8 @@ def get_discoveries():
     response = {
         'uniqueRecords': discoveries_count,
         'recordsFiltered': discoveries_count,
-        'recordsTotal': c.get_discoveries_count(repo_url=url,
-                                                state=state_filter),
+        'recordsTotal': len(discoveries) if file_name
+        else c.get_discoveries_count(url, state=state_filter),
         'stateFilter': state_filter,
         'data': sorted([{'snippet': keys[0],
                          'category': keys[1],
@@ -393,12 +393,12 @@ def get_discoveries():
                                           'id': i['id']
                                           } for i in list(values)],
                          } for keys, values in groupby(
-                             discoveries, lambda i:
-                             (i['snippet'], i['category'],
-                              States[i['state']].value))],
+                             discoveries,
+                             lambda i: (i['snippet'],
+                                        i['category'],
+                                        States[i['state']].value))],
                        key=lambda i: States[i[order_by]].value,
-                       reverse=order_direction == 'desc')
-    }
+                       reverse=order_direction == 'desc')}
 
     return jsonify(response)
 

--- a/ui/server.py
+++ b/ui/server.py
@@ -381,8 +381,8 @@ def get_discoveries():
     response = {
         'uniqueRecords': discoveries_count,
         'recordsFiltered': discoveries_count,
-        'recordsTotal': len(discoveries) if file_name
-        else c.get_discoveries_count(url, state=state_filter),
+        'recordsTotal': c.get_discoveries_count(url, state=state_filter,
+                                                file_name=file_name),
         'stateFilter': state_filter,
         'data': sorted([{'snippet': keys[0],
                          'category': keys[1],

--- a/ui/templates/discoveries/file.html
+++ b/ui/templates/discoveries/file.html
@@ -61,8 +61,8 @@
 <div class="topicHeaderWrapper underTopicHeaderWrapper">
   <h3 class="scanDescription">
     <span id="shownDiscoveriesCounter"></span>
-    <span id="totalDiscoveriesCounter"> {{discoveries_count}} total discoveries</span> 
-    <span id="totalDiscoveriesCounterWithBrackets"> ({{discoveries_count}} total discoveries)</span> 
+    <span id="totalDiscoveriesCounter"> {{discoveries_count}} total discoveries <b>in this file</b></span> 
+    <span id="totalDiscoveriesCounterWithBrackets"> ({{discoveries_count}} total discoveries <b>in this file</b>)</span> 
   </h3>
 </div>
 

--- a/ui/templates/discoveries/file.html
+++ b/ui/templates/discoveries/file.html
@@ -59,7 +59,11 @@
 </div>
 
 <div class="topicHeaderWrapper underTopicHeaderWrapper">
-  <h3 class="scanDescription"><span id="discoveriesCounter">{{discoveries_count}}</span> discoveries found</h3>
+  <h3 class="scanDescription">
+    <span id="shownDiscoveriesCounter"></span>
+    <span id="totalDiscoveriesCounter"> {{discoveries_count}} total discoveries</span> 
+    <span id="totalDiscoveriesCounterWithBrackets"> ({{discoveries_count}} total discoveries)</span> 
+  </h3>
 </div>
 
 <table id="discoveries-table" class="dataTable" style="width: 100%">

--- a/ui/templates/discoveries/file.html
+++ b/ui/templates/discoveries/file.html
@@ -61,8 +61,8 @@
 <div class="topicHeaderWrapper underTopicHeaderWrapper">
   <h3 class="scanDescription">
     <span id="shownDiscoveriesCounter"></span>
-    <span id="totalDiscoveriesCounter"> {{discoveries_count}} total discoveries <b>in this file</b></span> 
-    <span id="totalDiscoveriesCounterWithBrackets"> ({{discoveries_count}} total discoveries <b>in this file</b>)</span> 
+    <span id="totalDiscoveriesCounter"> {{discoveries_count}} total discoveries in this file</span> 
+    <span id="totalDiscoveriesCounterWithBrackets"> ({{discoveries_count}} total discoveries in this file)</span> 
   </h3>
 </div>
 


### PR DESCRIPTION
This PR targets this issue: https://github.com/SAP/credential-digger/issues/131
It now is possible to display the number of discoveries in more verbose way on the single file view.