### PR TITLE
[Feat + Fix] Faster calculations and retrieval of data + Fix breaking non-scalable UI

### DIFF
--- a/ui/backend/client_ui.py
+++ b/ui/backend/client_ui.py
@@ -49,8 +49,8 @@ class UiClient(Client):
         """
         query = '''SELECT repo_url,
                           COUNT(*) as total,
-                          sum(case when STATE='new' then 1 else 0 end) as tp 
-                          FROM discoveries 
+                          sum(case when STATE='new' then 1 else 0 end) as tp
+                          FROM discoveries
                           GROUP BY repo_url;
                 '''
         cursor = self.db.cursor()

--- a/ui/backend/client_ui.py
+++ b/ui/backend/client_ui.py
@@ -38,6 +38,26 @@ class UiClient(Client):
         result = cursor.fetchone()[0]
         return result
 
+    def get_all_discoveries_count(self):
+        """ Get the total number of discoveries and the number of True
+        Positives per repo
+
+        Returns
+        -------
+        list
+            A list of tuples containing (repo_url, total, true positive).
+        """
+        query = '''SELECT repo_url,
+                          COUNT(*) as total,
+                          sum(case when STATE='new' then 1 else 0 end) as tp 
+                          FROM discoveries 
+                          GROUP BY repo_url;
+                '''
+        cursor = self.db.cursor()
+        cursor.execute(query)
+        result = cursor.fetchall()
+        return result
+
     def get_files_summary(self, query, repo_url):
         """ Get aggregated discoveries info on all files of a repository.
 

--- a/ui/server.py
+++ b/ui/server.py
@@ -302,12 +302,21 @@ def scan_repo():
 
 @app.route('/get_repos')
 def get_repos():
+    # Get data from the database
     active_scans = _get_active_scans()
-
     repos = c.get_repos()
+    repos_metadata = c.get_all_discoveries_count()
+
     for repo in repos:
-        repo['total'] = c.get_discoveries_count(repo['url'])
-        repo['TP'] = c.get_discoveries_count(repo['url'], state='new')
+        for metadata in repos_metadata:
+            if(repo.get('total')):
+                continue
+            if(repo['url'] == metadata[0]):
+                repo['total'] = metadata[1]  # Total number of discoveries
+                repo['TP'] = metadata[2]  # Total number of true positives
+            else:
+                repo['total'] = 0
+                repo['TP'] = 0
         repo['scan_active'] = False
         if repo['url'] in active_scans:
             repo['scan_active'] = True


### PR DESCRIPTION
### Introduction
When the user scans a lot of repositories, they fill-up the database with multiple new entries. 
When the database grows in size, collecting data becomes a lengthy task and blocks the UI (by keeping the other SQL queries pending) resulting in a non-functional UI (home page).

### Fix
We propose doing the calculations of the metadata with a multi-purpose SQL query that returns the following:

- Number of discoveries per repo
- Number of **true positive** discoveries per repo (part of the total number of the discoveries calculated previously)

### Performance
| Database | Old Time     | New Time       |
|----------|--------------|----------------|
| SQLite   | ~ 14 seconds | ~ 2 seconds    |
| Postgres | ~ 7 seconds  | ~ 0.05 seconds |