### PR TITLE
fix missing repos with get_repos 

### DIFF
--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -952,8 +952,14 @@ class Client(Interface):
                    login_or_token=git_token,
                    verify=False)
         missing_ids = {}
-        repositories = g.get_user(username).get_repos()
+
+        user = g.get_user(username)
+        if user.type == 'Organization':
+            # If this is an org, we change API call
+            user = g.get_organization(username)
+        repositories = user.get_repos()
         repos_num = repositories.totalCount
+
         i = 0
         for repo in repositories:
             i += 1

--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -953,11 +953,20 @@ class Client(Interface):
                    verify=False)
         missing_ids = {}
 
-        user = g.get_user(username)
-        if user.type == 'Organization':
-            # If this is an org, we change API call
-            user = g.get_organization(username)
-        repositories = user.get_repos()
+        if g.get_user().login == username:
+            # Get the repos of the currently authenticated user
+            # The API for get_user(username) will return only the public
+            # repositories for that user, so it's not suitable to scan all the
+            # repos (private ones included) of the authenticated user
+            repositories = g.get_user().get_repos(affiliation='owner')
+            logger.debug('Scan repos of currently token-authenticated user')
+        else:
+            user = g.get_user(username)
+            if user.type == 'Organization':
+                # If this is an org, we have to change API call
+                user = g.get_organization(username)
+                logger.debug('Scan repos of an organization')
+            repositories = user.get_repos()
         repos_num = repositories.totalCount
 
         i = 0


### PR DESCRIPTION
This PR ~partially fix~ fixes #180 
Indeed, now private/internal repos of organizations are listed with a `get_repos` call.

~Nevertheless, this still doesn't work with users (only public repos are listed, even if the git token gives access to some private repos for a user). This may be related to an [issue of the library we are using](https://github.com/PyGithub/PyGithub/issues/1827).~

Furthermore, we distinguish between the authenticated user and other users when calling `scan_user`. This way, we can fetch all the repos (included the private ones) of the authenticated user. For other users, we'll have visibility only of public repos.
