### PR TITLE
Implement incremental snapshot scan

### DIFF
--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -834,9 +834,15 @@ class Client(Interface):
             The id of the discoveries detected by the scanner (excluded the
             ones classified as false positives).
         """
-        if self.get_repo(repo_url) != {} and not force:
-            raise ValueError(f'The repository \"{repo_url}\" has already been '
-                             'scanned. Please use \"force\" to rescan it.')
+        if self.get_repo(repo_url) != {}:
+            logger.info(f'The repository \"{repo_url}\" has already been '
+                        'scanned.')
+            if force:
+                logger.info('It will be rescanned (old discoveries will be '
+                            'deleted) due to force=True')
+            else:
+                logger.info('Only the diff with the previous scan will be '
+                            'considered')
 
         rules = self._get_scan_rules(category)
         scanner = GitFileScanner(rules)

--- a/credentialdigger/scanners/git_file_scanner.py
+++ b/credentialdigger/scanners/git_file_scanner.py
@@ -198,7 +198,7 @@ class GitFileScanner(GitScanner, FileScanner):
             A list of discoveries (dictionaries). If there are no discoveries
             return an empty list
         """
-        logger.debug('Compute diff between {commit_to} and {commit_from}')
+        logger.debug(f'Compute diff between {commit_to} and {commit_from}')
         # Instantiate commit objects (needed to calculate the diff)
         old_commit = repo.commit(commit_from)
         new_commit_snapshot = repo.commit(commit_to)

--- a/credentialdigger/scanners/git_file_scanner.py
+++ b/credentialdigger/scanners/git_file_scanner.py
@@ -213,6 +213,4 @@ class GitFileScanner(GitScanner, FileScanner):
                                diff_filter='AM')
 
         # Delegate the diff scan to the GitScanner parent class
-        discoveries = self._diff_worker(diff, new_commit_snapshot)
-
-        return discoveries
+        return self._diff_worker(diff, new_commit_snapshot)

--- a/credentialdigger/scanners/git_file_scanner.py
+++ b/credentialdigger/scanners/git_file_scanner.py
@@ -3,6 +3,7 @@ import os
 import shutil
 
 import hyperscan
+from git import GitCommandError
 
 from .file_scanner import FileScanner
 from .git_scanner import GitScanner
@@ -93,10 +94,35 @@ class GitFileScanner(GitScanner, FileScanner):
         #       be set to False
         project_path, repo = self.get_git_repo(repo_url, local_repo=False)
 
-        # Scan the snapshot of the repository either at the last commit of
-        # a branch or at a specific commit
-        discoveries = self._scan(
-            repo, branch_or_commit, max_depth, ignore_list)
+        # Get the commit id of the snapshot to scan
+        try:
+            commit_to = repo.git.log('-1', branch_or_commit,
+                                     pretty='format:"%H"').strip('"')
+            logger.debug(f'Branch {branch_or_commit} refers to commit id '
+                         f'{commit_to}')
+        except GitCommandError:
+            commit_to = branch_or_commit
+
+        commit_from = None
+        since_timestamp = kwargs.get('since_timestamp')
+        if since_timestamp:
+            commit_from = repo.git.log('-1', pretty='format:"%H"',
+                                       before=since_timestamp).strip('"')
+            logger.debug(f'Repo was already scanned at commit {commit_from}')
+
+        discoveries = []
+        if commit_from:
+            discoveries = self._scan_diff(repo, commit_to, commit_from)
+        else:
+            # Scan the snapshot of the repository either at the last commit of
+            # a branch or at a specific commit
+            discoveries = self._scan(
+                repo, commit_to, max_depth, ignore_list)
+
+        # # Scan the snapshot of the repository either at the last commit of
+        # # a branch or at a specific commit
+        # discoveries = self._scan(
+        #     repo, branch_or_commit, max_depth, ignore_list)
 
         # Delete repo folder
         shutil.rmtree(project_path)
@@ -155,3 +181,38 @@ class GitFileScanner(GitScanner, FileScanner):
                 all_discoveries.extend(file_discoveries)
 
         return all_discoveries
+
+    def _scan_diff(self, repo, commit_to, commit_from):
+        """ Perform the actual scan of the snapshot of the repository.
+
+        Parameters
+        ----------
+        repo: `git.GitRepo`
+            The repository object
+        commit_to: str
+        commit_from: str
+
+        Returns
+        -------
+        list
+            A list of discoveries (dictionaries). If there are no discoveries
+            return an empty list
+        """
+        logger.debug('Compute diff between {commit_to} and {commit_from}')
+        # Instantiate commit objects (needed to calculate the diff)
+        old_commit = repo.commit(commit_from)
+        new_commit_snapshot = repo.commit(commit_to)
+
+        # Get the diff between the two commits
+        # Ignore possible submodules (they are independent from this repo
+        diff = old_commit.diff(new_commit_snapshot,
+                               create_patch=True,
+                               ignore_submodules='all',
+                               ignore_all_space=True,
+                               unified=0,
+                               diff_filter='AM')
+
+        # Delegate the diff scan to the GitScanner parent class
+        discoveries = self._diff_worker(diff, new_commit_snapshot)
+
+        return discoveries

--- a/credentialdigger/scanners/git_file_scanner.py
+++ b/credentialdigger/scanners/git_file_scanner.py
@@ -190,7 +190,9 @@ class GitFileScanner(GitScanner, FileScanner):
         repo: `git.GitRepo`
             The repository object
         commit_to: str
+            The commit id of the snapshot to scan
         commit_from: str
+            The commit id of the old scan on the same repo
 
         Returns
         -------


### PR DESCRIPTION
Fix #160 

Old behaviour:
When the user choses to scan the snapshot of a repo that has already been scanned, the scan is denied (unless forced, but in this case all the old discoveries are deleted before the scan)

New behaviour
Now, we take the timestamp of the last scan, we use it to find the commit id of the repo closest to that time, and we compute the diff between the selected commit id (or branch name) and that commit