### PR TITLE
catch clone_repo exception

### DIFF
--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 
 import yaml
 from github import Github
+from git import GitCommandError
 from rich.progress import Progress
 
 from .models.model_manager import ModelManager
@@ -982,11 +983,16 @@ class Client(Interface):
             # Get repo clone url without .git at the end
             repo_url = repo.clone_url[:-4]
             logger.info(f'{i}/{repos_num}) Scanning {repo.url}')
-            missing_ids[repo_url] = self._scan(repo_url, scanner,
-                                               models=models,
-                                               debug=debug,
-                                               similarity=similarity,
-                                               git_token=git_token)
+            try:
+                missing_ids[repo_url] = self._scan(repo_url, scanner,
+                                                   models=models,
+                                                   debug=debug,
+                                                   similarity=similarity,
+                                                   git_token=git_token)
+            except GitCommandError:
+                logger.info(f"{i}/{repos_num} Ignore {repo_url} "
+                            "(it can not be cloned)")
+
         return missing_ids
 
     def scan_wiki(self, repo_url, category=None, models=None, debug=False,

--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -7,8 +7,8 @@ from collections import namedtuple
 from datetime import datetime, timezone
 
 import yaml
-from github import Github
 from git import GitCommandError
+from github import Github
 from rich.progress import Progress
 
 from .models.model_manager import ModelManager
@@ -990,8 +990,8 @@ class Client(Interface):
                                                    similarity=similarity,
                                                    git_token=git_token)
             except GitCommandError:
-                logger.info(f"{i}/{repos_num} Ignore {repo_url} "
-                            "(it can not be cloned)")
+                logger.warning(f'{i}/{repos_num} Ignore {repo_url} '
+                               '(it can not be cloned)')
 
         return missing_ids
 

--- a/credentialdigger/scanners/git_scanner.py
+++ b/credentialdigger/scanners/git_scanner.py
@@ -100,7 +100,7 @@ class GitScanner(BaseScanner):
                 GitRepo.clone_from(repo_url, project_path)
                 repo = GitRepo(project_path)
             except GitCommandError as e:
-                logger.debug("Repo can not be cloned")
+                logger.warning('Repo can not be cloned')
                 shutil.rmtree(project_path)
                 raise e
 

--- a/credentialdigger/scanners/git_scanner.py
+++ b/credentialdigger/scanners/git_scanner.py
@@ -100,6 +100,7 @@ class GitScanner(BaseScanner):
                 GitRepo.clone_from(repo_url, project_path)
                 repo = GitRepo(project_path)
             except GitCommandError as e:
+                logger.debug("Repo can not be cloned")
                 shutil.rmtree(project_path)
                 raise e
 


### PR DESCRIPTION
Added ```GitCommandError``` exception handler in ```scan_user```. The exception is raised when the repository cannot be cloned. This pull request solves issue #183 