### PR TITLE
upgrade to v4.9.2

### DIFF
--- a/credentialdigger/cli/get_discoveries.py
+++ b/credentialdigger/cli/get_discoveries.py
@@ -153,6 +153,10 @@ def export_csv(discoveries, client, save=False):
         If True, we do not ask the user to enter a file path for the CSV
         to be exported
     """
+    # If there were no discoveries, do not generate any report
+    if not discoveries:
+        console.print('[bold][!] No discoveries found. Report not generated.')
+        return
     # Check if --save is specified
     if not save:
         path = ''

--- a/credentialdigger/cli/get_discoveries.py
+++ b/credentialdigger/cli/get_discoveries.py
@@ -168,7 +168,7 @@ def export_csv(discoveries, client, save=False):
         path = save
 
     try:
-        csv_file = open(path, newline='', mode='w')
+        csv_file = open(path, newline='', mode='w', encoding='utf-8')
     except IOError as e:
         console.print(f'[red]{e}\n'
                       '[bold][!] Failed to export discoveries.[/]')

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def requirements():
 
 setuptools.setup(
     name='credentialdigger',
-    version='4.9.1',
+    version='4.9.2',
     author='SAP SE',
     maintainer='Marco Rosa, Slim Trabelsi',
     maintainer_email='marco.rosa@sap.com, slim.trabelsi@sap.com',


### PR DESCRIPTION
Fix a bug that made the CLI crash when `get_discoveries` had `--save` set, and no discoveries found (with or without `--state` set) for a repository.

