### PR TITLE
upgrade to v4.9.3

### DIFF
--- a/credentialdigger/client.py
+++ b/credentialdigger/client.py
@@ -969,6 +969,9 @@ class Client(Interface):
                             'relaunching the scan with force=True')
                 return []
 
+        # Strip '/' at the end of api endpoint
+        api_endpoint = api_endpoint.rstrip('/')
+
         rules = self._get_scan_rules(category)
         scanner = GitPRScanner(rules)
 
@@ -1014,6 +1017,8 @@ class Client(Interface):
         # Disable warnings due to verify=false at login
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
+        # Strip '/' at the end of api endpoint
+        api_endpoint = api_endpoint.rstrip('/')
         logger.debug(f'Use API endpoint {api_endpoint}')
 
         rules = self._get_scan_rules(category)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def requirements():
 
 setuptools.setup(
     name='credentialdigger',
-    version='4.9.2',
+    version='4.9.3',
     author='SAP SE',
     maintainer='Marco Rosa, Slim Trabelsi',
     maintainer_email='marco.rosa@sap.com, slim.trabelsi@sap.com',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3',
         'Operating System :: OS Independent',
     ],
-    python_requires='>3.5, <3.10',
+    python_requires='>3.5, <3.11',
     entry_points={'console_scripts': ['credentialdigger=credentialdigger'
                                       '.__main__:main']},
 )


### PR DESCRIPTION
Fix bug when api endpoint was declared with a trailing `/`.

Add python3.10 support in `setup.py` that prevented the download of the tool from pypi. 
