### PR TITLE
Bump hyperscan dep

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,8 @@ jobs:
         pip install . --user
 
     - name: Install tests dependencies
-       run: |
-         pip install -r ./tests/tests-requirements.txt
+      run: |
+        pip install -r ./tests/tests-requirements.txt
 
     - name: Run unit tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Install OS dependencies
       run: |
-        sudo apt install -y build-essential python3-dev libhyperscan-dev
+        sudo apt install -y build-essential python3-dev
 
     - name: Cache python dependencies
       uses: actions/cache@v3
@@ -53,14 +53,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Install python dependencies
-      run: |
-        pip install -r ./requirements.txt
-        pip install -r ./tests/tests-requirements.txt
-
     - name: Install credentialdigger
       run: |
-        python setup.py install --user
+        pip install . --user
 
     - name: Run unit tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,10 @@ jobs:
       run: |
         pip install . --user
 
+    - name: Install tests dependencies
+       run: |
+         pip install -r ./tests/tests-requirements.txt
+
     - name: Run unit tests
       run: |
         pytest tests/unit_tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
 
     services:
       postgres:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        #python-version: ['3.7', '3.8', '3.9', '3.10']
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     services:
       postgres:

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ The goal of Credential Digger is to reduce the amount of false positive data on 
 
 
 The tool supports several scan flavors: public and private repositories on
-github and gitlab, wiki pages, github organizations, local git repositories, local files and folders.
+github and gitlab, pull requests, wiki pages, github organizations, local git repositories, local files and folders.
 Please refer to the [Wiki](https://github.com/SAP/credential-digger/wiki) for the complete documentation.
 
-For the complete description of the approach of Credential Digger, [you can read this publication](https://www.scitepress.org/Papers/2021/102381/102381.pdf).
+For the complete description of the approach of Credential Digger (versions <4.4), [you can read this publication](https://www.scitepress.org/Papers/2021/102381/102381.pdf).
 
 ```
 @InProceedings {lrnto-icissp21,
@@ -63,22 +63,16 @@ For the complete description of the approach of Credential Digger, [you can read
 
 ## Requirements
 
-Credential Digger supports Python >= 3.6 and < 3.10, and works only with Linux and MacOS systems.
+Credential Digger supports Python >= 3.8 and < 3.12, and works only with Linux and MacOS systems.
 In case you don't meet these requirements, you may consider running a [Docker container](#docker) (that also includes a user interface).
 
 
 ## Download and Installation
 
-First, you need to install the regular expression matching library [Hyperscan](https://github.com/intel/hyperscan). Be sure to have `build-essential` and `python3-dev` too.
+First, you need to install some dependencies (namely, `build-essential` and `python3-dev`). No need to explicitely install hyperscan anymore.
 
 ```bash
-sudo apt install -y libhyperscan-dev build-essential python3-dev
-```
-
-or (for MacOS):
-
-```bash
-brew install hyperscan
+sudo apt install -y build-essential python3-dev
 ```
 
 Then, you can install Credential Digger module using `pip`.
@@ -122,8 +116,16 @@ credentialdigger scan https://github.com/user/repo --sqlite /path/to/data.db --s
 
 ## Docker container
 
-To have a ready-to-use instance of Credential Digger, with a user interface, you can build the docker container. 
+To have a ready-to-use instance of Credential Digger, with a user interface, you can use a docker container. 
 This option requires the installation of [Docker](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/).
+
+Credential Digger is published on [dockerhub](https://hub.docker.com/r/saposs/credentialdigger). You can pull the latest release
+
+```bash
+sudo docker pull saposs/credentialdigger
+```
+
+Or build and run containers with docker-compose
 
 ```bash
 git clone https://github.com/SAP/credential-digger.git

--- a/README.md
+++ b/README.md
@@ -157,11 +157,10 @@ git clone https://github.com/SAP/credential-digger.git
 cd credential-digger
 ```
 
-Install the requirements from `requirements.txt` file and install the library:
+Install the tool from source:
 
 ```bash
-pip install -r requirements.txt
-python setup.py install
+pip install .
 ```
 
 Then, you can add the rules and scan a repository as described above.

--- a/credentialdigger/scanners/file_scanner.py
+++ b/credentialdigger/scanners/file_scanner.py
@@ -157,8 +157,7 @@ class FileScanner(BaseScanner):
                 for row in file_to_scan:
                     rh = ResultHandler()
                     self.stream.scan(
-                        row if sys.version_info < (3, 8) else row.encode(
-                            'utf-8'),
+                        row.encode('utf-8'),
                         match_event_handler=rh.handle_results,
                         context=[row.strip(), relative_path, commit_id,
                                  line_number]

--- a/credentialdigger/scanners/git_scanner.py
+++ b/credentialdigger/scanners/git_scanner.py
@@ -406,7 +406,7 @@ class GitScanner(BaseScanner):
 
             rh = ResultHandler()
             self.stream.scan(
-                row if sys.version_info < (3, 8) else row.encode('utf-8'),
+                row.encode('utf-8'),
                 match_event_handler=rh.handle_results,
                 context=[row, filename, commit_hash, line_number])
             if rh.result:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ python-dotenv
 pyyaml
 rich~=12.2
 srsly>=2.4.0
-tensorflow==2.11.1; python_version >= "3.8"
-tensorflow-estimator==2.11.0; python_version >= "3.8"
-tensorflow-text==2.11.0; python_version >= "3.8"
+tensorflow==2.14.0
+tensorflow-estimator==2.14.0
+tensorflow-text==2.14.0
 tf-models-official
 transformers

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 Flask
 flask_jwt_extended
 GitPython
-hyperscan==0.6.0
+hyperscan==0.6.0; python_version != "3.9"
+hyperscan==0.5.0; python_version == "3.9"
 numpy
 pandas
 psycopg2-binary

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,11 @@ python-dotenv
 pyyaml
 rich~=12.2
 srsly>=2.4.0
-tensorflow==2.14.0
-tensorflow-estimator==2.14.0
-tensorflow-text==2.14.0
+tensorflow==2.14.0; python_version > "3.8"
+tensorflow==2.13.1; python_version <= "3.8"
+tensorflow-estimator==2.14.0; python_version > "3.8"
+tensorflow-estimator==2.13.0; python_version <= "3.8"
+tensorflow-text==2.14.0; python_version > "3.8"
+tensorflow-text==2.13.0; python_version <= "3.8"
 tf-models-official
 transformers

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 Flask
 flask_jwt_extended
 GitPython
-hyperscan==0.2.0; python_version >= "3.8"
-hyperscan==0.1.5; python_version < "3.8"
+hyperscan==0.6.0
 numpy
 pandas
 psycopg2-binary
@@ -12,10 +11,7 @@ pyyaml
 rich~=12.2
 srsly>=2.4.0
 tensorflow==2.11.1; python_version >= "3.8"
-tensorflow~=2.4; python_version < "3.8"
 tensorflow-estimator==2.11.0; python_version >= "3.8"
-tensorflow-estimator~=2.4; python_version < "3.8"
 tensorflow-text==2.11.0; python_version >= "3.8"
-tensorflow-text~=2.4; python_version < "3.8"
 tf-models-official
 transformers

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3',
         'Operating System :: OS Independent',
     ],
-    python_requires='>3.5, <3.11',
+    python_requires='>3.7, <3.12',
     entry_points={'console_scripts': ['credentialdigger=credentialdigger'
                                       '.__main__:main']},
 )


### PR DESCRIPTION
Bump hyperscan dependency.
hyperscan v0.6 should work seamlessly on all python versions and should not require any hyperscan package to be installed upfront on the OS -> TODO: update README and Docker container image