### PR TITLE
Added error in case of broken scan

### DIFF
--- a/ui/res/js/repos.js
+++ b/ui/res/js/repos.js
@@ -88,9 +88,9 @@ function initReposDataTable() {
               </div>`,
               scan_active: item.scan_active
                 ? `
-              <span class="icon icon-timelapse warning-color"></span>
-            `
-                : `
+              <span class="icon icon-timelapse warning-color"></span>`
+                : (item.TP + item.total) === 0 ? 
+                `<span class="icon icon-error_outline danger-color"></span>`:`
               <span class="icon icon-check_circle_outline success-color"></span>`,
               lendiscoveries: item.TP + ` (${item.total} Total)`,
               actions: `


### PR DESCRIPTION
## Description
Added a check to ensure a broken scan has a error icon in the UI

## Linked Issue
Closes #230

## Approach
As descirbe in the following [comment ](https://github.com/SAP/credential-digger/issues/230#issuecomment-2424306657), we have 2 possible ways to check if the scan was broken. I decided to go where we dont the one where adding new fields to the models and rely on the TP and total discoveries to check broken scans. If this is not correct please inform me of a better check.

## Screenshots
![Screenshot 2024-10-27 220034](https://github.com/user-attachments/assets/6878d4c5-8701-4c87-be47-823939f7cd75)
