### PR TITLE
Update scan snapshot to pass default value of empty list

### DIFF
--- a/src/credentialdigger/cli/scan_snapshot.py
+++ b/src/credentialdigger/cli/scan_snapshot.py
@@ -103,7 +103,7 @@ def configure_parser(parser):
         help='Maximum depth for subdirectories scanning (If it is set to -1 or\
             not specified, all subdirectories will be scanned)')
     parser.add_argument(
-        '--ignore_list', default=None, nargs='+',
+        '--ignore_list', default=[], nargs='+',
         help='A list of paths to ignore during the scan')
 
 

--- a/tests/unit_tests/test_file_scanner.py
+++ b/tests/unit_tests/test_file_scanner.py
@@ -85,21 +85,22 @@ class TestFileScanner(unittest.TestCase):
             ignore_list=["subdir_A", "file_b.txt"],
             expected_ignored_dirs=["subdir_A"],
             expected_ignored_files=["file_b.txt"]),
-        # Test names with wildcards
+        # Test wildcard ignores all files that have substring `_A`
         param(
-            ignore_list=["*_a*"],
+            ignore_list=["*_A*"],
             expected_ignored_dirs=[],
-            expected_ignored_files=["file_a.txt", "scan_a.py"]),
-        # Test wildcard ignores all files that end with .txt
+            expected_ignored_files=["file_Aa.yml", "file_ABa.txt"]),
+        # Test wildcard ignores all files that end with `.txt`
         param(
             ignore_list=["*.txt"],
             expected_ignored_dirs=[""],
-            expected_ignored_files=["file_b.txt", "file_ABa.txt"]),
+            expected_ignored_files=["scan_b.txt", "file_ABa.txt"]),
         # Test wildcard ignores dir and all files within
         param(
             ignore_list=["*subdir_A*"],
             expected_ignored_dirs=["subdir_A", "subdir_AB"],
             expected_ignored_files=["file_Aa.yml", "file_ABa.txt"]),
+        # Test nonexistent files and wildcards
         param(
             ignore_list=["nonexistent_file.txt", "*z*"],
             expected_ignored_dirs=[],

--- a/tests/unit_tests/test_file_scanner.py
+++ b/tests/unit_tests/test_file_scanner.py
@@ -90,6 +90,11 @@ class TestFileScanner(unittest.TestCase):
             ignore_list=["*_a*"],
             expected_ignored_dirs=[],
             expected_ignored_files=["file_a.txt", "scan_a.py"]),
+        # Test wildcards of dir ignore dir and all files wthin
+        param(
+            ignore_list=["*subdir_A*"],
+            expected_ignored_dirs=["subdir_A", "subdir_AB"],
+            expected_ignored_files=["file_Aa.yml", "file_ABa.txt"]),
         # Test nonexistent files and wildcards
         param(
             ignore_list=["nonexistent_file.txt", "*z*"],

--- a/tests/unit_tests/test_file_scanner.py
+++ b/tests/unit_tests/test_file_scanner.py
@@ -90,12 +90,16 @@ class TestFileScanner(unittest.TestCase):
             ignore_list=["*_a*"],
             expected_ignored_dirs=[],
             expected_ignored_files=["file_a.txt", "scan_a.py"]),
-        # Test wildcards of dir ignore dir and all files wthin
+        # Test wildcard ignores all files that end with .txt
+        param(
+            ignore_list=["*.txt"],
+            expected_ignored_dirs=[""],
+            expected_ignored_files=["file_b.txt", "file_ABa.txt"]),
+        # Test wildcard ignores dir and all files within
         param(
             ignore_list=["*subdir_A*"],
             expected_ignored_dirs=["subdir_A", "subdir_AB"],
             expected_ignored_files=["file_Aa.yml", "file_ABa.txt"]),
-        # Test nonexistent files and wildcards
         param(
             ignore_list=["nonexistent_file.txt", "*z*"],
             expected_ignored_dirs=[],


### PR DESCRIPTION
# Description
Addressing issue for credential digger cli where scan_snapshot argument is passing a `None` value instead of an empty list `[]`. 

This has been similarly done for scan_path and was fixed in PR https://github.com/SAP/credential-digger/pull/319

Also additionally added/fixed basic unit tests related to file scanner.

# Linked Issue
Closes https://github.com/SAP/credential-digger/issues/333
